### PR TITLE
AndroidUtils > scroll > adding better handling for catching re-throwi…

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/AndroidUtils.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/AndroidUtils.java
@@ -323,10 +323,7 @@ public class AndroidUtils extends MobileUtils {
                     break;
                 }
             } catch (NoSuchElementException noSuchElement) {
-                throw new NoSuchElementException(String.format("Element %s:%s was NOT found.", eleSelectorType, scrollToEle), noSuchElement);
-            } catch (Exception e) {
-                LOGGER.error("Element NOT found!!!");
-                throw e;
+                LOGGER.error(String.format("Element %s:%s was NOT found.", eleSelectorType, scrollToEle), noSuchElement);
             }
 
             for (int j = 0; j < i; j++) {
@@ -375,10 +372,7 @@ public class AndroidUtils extends MobileUtils {
                     break;
                 }
             } catch (NoSuchElementException noSuchElement) {
-                throw new NoSuchElementException(String.format("Element %s:%s was NOT found.", eleSelectorType, scrollToEle), noSuchElement);
-            } catch (Exception e) {
-                LOGGER.error("Element NOT found!!!");
-                throw e;
+                LOGGER.error(String.format("Element %s:%s was NOT found.", eleSelectorType, scrollToEle), noSuchElement);
             }
 
             for (int j = 0; j < i; j++) {
@@ -424,10 +418,7 @@ public class AndroidUtils extends MobileUtils {
                     break;
                 }
             } catch (NoSuchElementException noSuchElement) {
-                throw new NoSuchElementException(String.format("Element %s:%s was NOT found.", eleSelectorType, scrollToEle), noSuchElement);
-            } catch (Exception e) {
-                LOGGER.error("Element NOT found!!!");
-                throw e;
+                LOGGER.error(String.format("Element %s:%s was NOT found.", eleSelectorType, scrollToEle), noSuchElement);
             }
 
             for (int j = 0; j < i; j++) {


### PR DESCRIPTION
…ng exception. Moving re-throwing NoSuchElementException exception into checkTimeout(), otherwise, re-throwing NoSuchElementException in second catch block prevents scroll.pageForward() execution in times when scroll gets stuck before reaching the end of the scrollable container. 