### PR TITLE
Updating loggers in CustomTypePageFactory to make it easier to debug when theres a problem

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/factory/CustomTypePageFactory.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/factory/CustomTypePageFactory.java
@@ -83,15 +83,14 @@ public class CustomTypePageFactory {
         LOGGER.debug("Major version of device OS: " + majorVersionNumber);
         for (Class<? extends T> clazz : setClasses) {
             if (clazz.getAnnotation(DeviceType.class) == null || clazz.getAnnotation(DeviceType.class).parentClass() != parentClass) {
-                LOGGER.debug("Removing as parentClass is not satisfied or due to absence of @DeviceType annotation:"
-                        + clazz.getClass().getName());
+                LOGGER.debug(
+                        String.format("Removing as parentClass (%s) is not satisfied or due to absence of @DeviceType annotation on class: %s", parentClass.getName(), clazz.getName()));
                 continue;
             }
             DeviceType dt = clazz.getAnnotation(DeviceType.class);
 
+            LOGGER.debug(String.format("Expected screenType: %s, Actual screenType: %s", screenType, dt.pageType()));
             if (dt.pageType().equals(screenType)) {
-                LOGGER.debug("Expected screenType: " + screenType);
-                LOGGER.debug("Actual screenType: " + dt.pageType());
                 if (Arrays.asList(dt.version()).contains(deviceVersion)) {
                     LOGGER.debug("Expected version: " + deviceVersion);
                     LOGGER.debug("Actual versions: " + dt.version());


### PR DESCRIPTION
First change prevents the LOGGER.debug from just returning just (java.lang.Class) all the time, and returns the actual class name.

The second change looks like the expected/actual would always be the same as it was doing the check after it did an equals on it, so moved it up a level so we can see when differences do occur.