### PR TITLE
Adding workaround for appium client issue with uiautomator > scrollIn…

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/AndroidUtils.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/AndroidUtils.java
@@ -18,6 +18,7 @@ package com.qaprosoft.carina.core.foundation.utils.android;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
@@ -326,6 +327,15 @@ public class AndroidUtils extends MobileUtils {
 		// TODO: support multi threaded WebDriver's removing DriverPool usage
 		WebDriver drv = getDriver();
 
+        //workaorund for appium issue: https://github.com/appium/appium/issues/10159
+        if (scrollToEle.contains(",")) {
+            scrollToEle = StringUtils.join(StringUtils.split(scrollToEle, ","),
+                    ",", 0, 2);
+            if (eleSelectorType.equals(SelectorType.TEXT)) {
+                eleSelectorType = SelectorType.TEXT_CONTAINS;
+            }
+        }
+
         for (int i = 0; i < SCROLL_MAX_SEARCH_SWIPES; i++) {
 
             try {
@@ -378,6 +388,14 @@ public class AndroidUtils extends MobileUtils {
 		// TODO: support multi threaded WebDriver's removing DriverPool usage
 		WebDriver drv = getDriver();
 
+        //workaorund for appium issue: https://github.com/appium/appium/issues/10159
+        if (scrollToEle.contains(",")) {
+            scrollToEle = StringUtils.join(StringUtils.split(scrollToEle, ","),
+                    ",", 0, 2);
+            if (eleSelectorType.equals(SelectorType.TEXT)) {
+                eleSelectorType = SelectorType.TEXT_CONTAINS;
+            }
+        }
 
         for (int i = 0; i < SCROLL_MAX_SEARCH_SWIPES; i++) {
 
@@ -429,6 +447,15 @@ public class AndroidUtils extends MobileUtils {
         long startTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
 		// TODO: support multi threaded WebDriver's removing DriverPool usage
 		WebDriver drv = getDriver();
+
+        //workaorund for appium issue: https://github.com/appium/appium/issues/10159
+        if (scrollToEle.contains(",")) {
+            scrollToEle = StringUtils.join(StringUtils.split(scrollToEle, ","),
+                    ",", 0, 2);
+            if (eleSelectorType.equals(SelectorType.TEXT)) {
+                eleSelectorType = SelectorType.TEXT_CONTAINS;
+            }
+        }
 
         for (int i = 0; i < SCROLL_MAX_SEARCH_SWIPES; i++) {
 


### PR DESCRIPTION
…toView()
- Implemented modification for AndroidUtils > scroll methods to handle existing issue with scrollIntoView() that would take care of the crash if more than 1 comma present in the string that is used to locate element by text(). Existing appium client issue for this can be found here: https://github.com/appium/appium/issues/10159. 