### PR TITLE
Handling screenshots for emerging alerts and closed pop-ups

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -355,7 +355,10 @@ public class Screenshot {
             } catch (IOException e) {
                 LOGGER.error("Unable to capture screenshot due to the I/O issues!", e);
             } catch (WebDriverException e) {
-                if (e.getMessage() != null && e.getMessage().contains("current view have 'secure' flag set")) {
+                if (e.getMessage() != null && (e.getMessage().contains("current view have 'secure' flag set")
+                        || e.getMessage().contains("no such window: window was already closed")
+                        || e.getMessage().contains("Error communicating with the remote browser. It may have died")
+                        || e.getMessage().contains("unexpected alert open"))) {
                     LOGGER.warn("Unable to capture screenshot: " + e.getMessage());
                 } else {
                     throw e;


### PR DESCRIPTION
Modius has buttons, that open / close a pop-up or alert. Making a screenshot after such actions leads to an unhandled exception and test failure. There is a workaround for that inside.