### PR TITLE
build-snapshot: Updated appium java client to 7.0.0 version

### DIFF
--- a/carina-core/src/main/resources/config.properties
+++ b/carina-core/src/main/resources/config.properties
@@ -191,6 +191,7 @@ screen_record_pass=qpsdemo
 screen_record_size=480x640
 screen_record_duration=180
 screen_record_quality=MEDIUM
+screen_record_ios_codec=libx264
 #=====================================================#
 
 #======== Test Execution Filter Rules  ===============#

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/MobileFactory.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/MobileFactory.java
@@ -47,7 +47,6 @@ import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.IOSElement;
 import io.appium.java_client.ios.IOSStartScreenRecordingOptions;
 import io.appium.java_client.ios.IOSStartScreenRecordingOptions.VideoQuality;
-import io.appium.java_client.ios.IOSStartScreenRecordingOptions.VideoType;
 import io.appium.java_client.ios.IOSStopScreenRecordingOptions;
 
 /**
@@ -128,7 +127,8 @@ public class MobileFactory extends AbstractFactory {
                         
                         IOSStartScreenRecordingOptions o1 = new IOSStartScreenRecordingOptions()
                                 .withVideoQuality(VideoQuality.valueOf(R.CONFIG.get("screen_record_quality")))
-                                .withVideoType(VideoType.H264)
+                                // TODO [nkrasnik]: appium_client 7.0.0 requirments https://github.com/appium/java-client/releases/tag/v7.0.0
+                                .withVideoType(R.CONFIG.get("screen_record_ios_codec"))
                                 .withTimeLimit(Duration.ofSeconds(R.CONFIG.getInt("screen_record_duration")));
 
                         IOSStopScreenRecordingOptions o2 = new IOSStopScreenRecordingOptions();

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <!-- Selenium -->
         <selenium-java.version>3.141.59</selenium-java.version>
         <selenium-server.version>3.141.59</selenium-server.version>
-        <appium.version>6.1.0</appium.version>
+        <appium.version>7.0.0</appium.version>
         <!-- Qaprosoft integrations -->
         <zafira-client.version>3.3.49</zafira-client.version>
         <alice-client.version>1.1.0</alice-client.version>


### PR DESCRIPTION
Updates related to video recording for iOS. VideoType enum has been removed. For now we should you string parameter.
Added string parameter to config.properties, updated MobileFactory class.
