### PR TITLE
build-snapshot: temp fix for abstract ui objects

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/ExtendedWebElement.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/ExtendedWebElement.java
@@ -409,7 +409,11 @@ public class ExtendedWebElement {
         this.by = by;
     }
 
-    @Override
+	public void setSearchContext(SearchContext searchContext) {
+		this.searchContext = searchContext;
+	}
+
+	@Override
     public String toString() {
         return name;
     }
@@ -1024,7 +1028,11 @@ public class ExtendedWebElement {
      */
     public ExtendedWebElement findExtendedWebElement(final By by, String name, long timeout) {
         if (isPresent(by, timeout)) {
-        	return new ExtendedWebElement(getElement().findElement(by), name, by);
+			try {
+				return new ExtendedWebElement(getCachedElement().findElement(by), name, by);
+			} catch (StaleElementReferenceException e) {
+				return new ExtendedWebElement(getElement().findElement(by), name, by);
+			}
         } else {
         	throw new NoSuchElementException("Unable to find dynamic element using By: " + by.toString());
         }
@@ -1039,7 +1047,11 @@ public class ExtendedWebElement {
         List<WebElement> webElements = new ArrayList<WebElement>();
         
         if (isPresent(by, timeout)) {
-        	webElements = getElement().findElements(by);
+			try {
+				webElements = getCachedElement().findElements(by);
+			} catch (StaleElementReferenceException e) {
+				webElements = getElement().findElements(by);
+			}
         } else {
         	throw new NoSuchElementException("Unable to find dynamic elements using By: " + by.toString());
         }
@@ -1799,14 +1811,14 @@ public class ExtendedWebElement {
         return resBy;
     }
     
-    private ExpectedCondition<?> getDefaultCondition(By myBy) {
+/*	private ExpectedCondition<?> getDefaultCondition(By myBy) {
         // generate the most popular wiatCondition to check if element visible or present
         return ExpectedConditions.or(ExpectedConditions.presenceOfElementLocated(myBy),
                 ExpectedConditions.visibilityOfElementLocated(myBy));
-    }
-    
+    }*/
+
     // old functionality to remove completely after successfull testing
-/*    private ExpectedCondition<?> getDefaultCondition(By myBy) {
+    private ExpectedCondition<?> getDefaultCondition(By myBy) {
         // generate the most popular wiatCondition to check if element visible or present
         ExpectedCondition<?> waitCondition = null;
         if (element != null) {
@@ -1819,5 +1831,5 @@ public class ExtendedWebElement {
         }
 
         return waitCondition;
-    }*/
+    }
 }

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/locator/internal/LocatingElementListHandler.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/locator/internal/LocatingElementListHandler.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.qaprosoft.carina.core.foundation.webdriver.locator.internal;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -24,6 +25,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -81,6 +83,9 @@ public class LocatingElementListHandler implements InvocationHandler {
 				}
 
 				ExtendedWebElement tempElement = new ExtendedWebElement(element, tempName, by);
+				Field searchContextField = locator.getClass().getDeclaredField("searchContext");
+				searchContextField.setAccessible(true);
+				tempElement.setSearchContext((SearchContext) searchContextField.get(locator));
 //				tempElement.setBy(tempElement.generateByForList(by, i));
 				extendedWebElements.add(tempElement);
 				i++;


### PR DESCRIPTION
- getDefaultCondition() in ExtendedWebElement reverted to previous version to fix https://github.com/qaprosoft/carina/issues/636
- findExtendedWebElement() in ExtendedWebElement was fixed to use cachedElement with valid search context instead of finding root element every time what breaks search context for list of elements
- ^ same for findExtendedWebElements()