### PR TITLE
#653 Updated capturing full size screenshots on Mac OS system

### DIFF
--- a/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
+++ b/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
@@ -175,4 +175,23 @@ public class SpecialKeywords {
     public static final String RULE_FILTER_SPLITTER = ";;";
     public static final String RULE_FILTER_AND_CONDITION = "&&";
 
+
+    // ------------- Mobile screenshots cutting strategies configuration  ---------------
+    public static final int DEFAULT_SCROLL_TIMEOUT = 100;
+    public static final int DEFAULT_HEADER = 0;
+    public static final int DEFAULT_FOOTER = 0;
+    public static final int DEFAULT_IOS_HEADER = 72;
+    public static final int DEFAULT_IOS_IPAD_HEADER = 102;
+    public static final int DEFAULT_IOS_X_HEADER = 92;
+    public static final int DEFAULT_IOS_PLUS_HEADER = 82;
+    public static final int DEFAULT_IOS_SE_HEADER = 52;
+    public static final int DEFAULT_IOS_SE_FOOTER = 38;
+    public static final int DEFAULT_IOS_X_FOOTER = 42;
+    public static final float IPHONE_DEFAULT_DPR= 2.0F;
+    public static final float IPHONE_X_DPR= 3.0F;
+    public static final float IPHONE_PLUS_DPR= 2.608F;
+    public static final int DEFAULT_PLUS_WIDTH= 414;
+    public static final int DEFAULT_IPAD_WIDTH= 768;
+    public static final int DEFAULT_SE_WIDTH= 320;
+    public static final int DEFAULT_IOS_X_HEIGHT= 812;
 }

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -467,6 +467,11 @@ public class Screenshot {
         } else if (Configuration.getDriverType().equals(SpecialKeywords.MOBILE)) {
             // Mobile web
             screenShot = ImageIO.read(((TakesScreenshot) augmentedDriver).getScreenshotAs(OutputType.FILE));
+        } else if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+            // Mac OS web
+            ru.yandex.qatools.ashot.Screenshot screenshot = new AShot()
+                    .shootingStrategy(ShootingStrategies.viewportRetina(100, 0, 0, 2)).takeScreenshot(augmentedDriver);
+            screenShot = screenshot.getImage();
         } else {
             // regular web
             ru.yandex.qatools.ashot.Screenshot screenshot = new AShot()

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -187,7 +187,7 @@ public class Screenshot {
      * @return screenshot name.
      */
     public static BufferedImage captureFullSize(WebDriver driver, String comment) {
-        String screenName = "";
+        String screenName;
         BufferedImage screen = null;
 
         LOGGER.debug("Screenshot->capture starting...");
@@ -540,8 +540,7 @@ public class Screenshot {
             ru.yandex.qatools.ashot.Screenshot screenshot;
             if (Configuration.getPlatform().equals("ANDROID")) {
                 String pixelRatio = String.valueOf(IDriverPool.getDefaultDevice().getCapabilities().getCapability("pixelRatio"));
-                // float dpr = Float.parseFloat(pixelRatio);
-                Float dpr = Float.valueOf(pixelRatio);
+                float dpr = Float.parseFloat(pixelRatio);
                 screenshot = (new AShot()).shootingStrategy(ShootingStrategies
                         .viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_HEADER, SpecialKeywords.DEFAULT_FOOTER, dpr))
                         .takeScreenshot(augmentedDriver);
@@ -550,33 +549,38 @@ public class Screenshot {
                 int deviceWidth = augmentedDriver.manage().window().getSize().getWidth();
                 switch (deviceWidth) {
                 case SpecialKeywords.DEFAULT_PLUS_WIDTH: {
-                    screenshot = new AShot().shootingStrategy(ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_PLUS_HEADER,
-                            SpecialKeywords.DEFAULT_FOOTER, SpecialKeywords.IPHONE_PLUS_DPR)).takeScreenshot(augmentedDriver);
+                    screenshot = new AShot().shootingStrategy(
+                            ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_PLUS_HEADER,
+                                    SpecialKeywords.DEFAULT_FOOTER, SpecialKeywords.IPHONE_PLUS_DPR)).takeScreenshot(augmentedDriver);
                     screenShot = screenshot.getImage();
                     break;
                 }
                 case SpecialKeywords.DEFAULT_IPAD_WIDTH: {
-                    screenshot = new AShot().shootingStrategy(ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_IPAD_HEADER,
-                            SpecialKeywords.DEFAULT_FOOTER, SpecialKeywords.IPHONE_DEFAULT_DPR)).takeScreenshot(augmentedDriver);
+                    screenshot = new AShot().shootingStrategy(
+                            ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_IPAD_HEADER,
+                                    SpecialKeywords.DEFAULT_FOOTER, SpecialKeywords.IPHONE_DEFAULT_DPR)).takeScreenshot(augmentedDriver);
                     screenShot = screenshot.getImage();
                     break;
                 }
                 case SpecialKeywords.DEFAULT_SE_WIDTH: {
-                    screenshot = new AShot().shootingStrategy(ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_SE_HEADER,
-                            SpecialKeywords.DEFAULT_IOS_SE_FOOTER, SpecialKeywords.IPHONE_DEFAULT_DPR)).takeScreenshot(augmentedDriver);
+                    screenshot = new AShot().shootingStrategy(
+                            ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_SE_HEADER,
+                                    SpecialKeywords.DEFAULT_IOS_SE_FOOTER, SpecialKeywords.IPHONE_DEFAULT_DPR)).takeScreenshot(augmentedDriver);
                     screenShot = screenshot.getImage();
                     break;
                 }
                 default: {
                     int height = augmentedDriver.manage().window().getSize().getHeight();
                     if (height == SpecialKeywords.DEFAULT_IOS_X_HEIGHT) {
-                        screenshot = new AShot().shootingStrategy(ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_X_HEADER,
-                                SpecialKeywords.DEFAULT_IOS_X_FOOTER, SpecialKeywords.IPHONE_X_DPR)).takeScreenshot(augmentedDriver);
+                        screenshot = new AShot().shootingStrategy(
+                                ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_X_HEADER,
+                                        SpecialKeywords.DEFAULT_IOS_X_FOOTER, SpecialKeywords.IPHONE_X_DPR)).takeScreenshot(augmentedDriver);
                         screenShot = screenshot.getImage();
                         break;
                     } else {
-                        screenshot = new AShot().shootingStrategy(ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_HEADER,
-                                SpecialKeywords.DEFAULT_FOOTER, SpecialKeywords.IPHONE_DEFAULT_DPR)).takeScreenshot(augmentedDriver);
+                        screenshot = new AShot().shootingStrategy(
+                                ShootingStrategies.viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_IOS_HEADER,
+                                        SpecialKeywords.DEFAULT_FOOTER, SpecialKeywords.IPHONE_DEFAULT_DPR)).takeScreenshot(augmentedDriver);
                         screenShot = screenshot.getImage();
                         break;
                     }
@@ -656,55 +660,64 @@ public class Screenshot {
 		return !disableScreenshot;
 	}
 
-	/**
+    /**
      * Compares two different screenshots
      *
-     *
-     * @param bufferedImageExpected
-     *                      - old image
-     * @param bufferedImageActual
-     *                      - new image
-     *
+     * @param bufferedImageExpected - old image
+     * @param bufferedImageActual   - new image
      * @return boolean
-     * */
-    public static boolean isScreenshotDiff(BufferedImage bufferedImageExpected, BufferedImage bufferedImageActual) throws IOException {
+     */
+    public static boolean isScreenshotDiff(BufferedImage bufferedImageExpected, BufferedImage bufferedImageActual) {
         String screenName;
         BufferedImage screen;
+        try {
+            ImageDiffer imageDiff = new ImageDiffer();
+            ImageDiff diff = imageDiff.makeDiff(bufferedImageExpected, bufferedImageActual);
+            if (diff.hasDiff()) {
+                screen = diff.getMarkedImage();
+                Timer.start(ACTION_NAME.CAPTURE_SCREENSHOT);
+                // Define test screenshot root
+                File testScreenRootDir = ReportContext.getTestDir();
 
-        ImageDiffer imageDiff = new ImageDiffer();
-        ImageDiff diff = imageDiff.makeDiff(bufferedImageExpected, bufferedImageActual);
-        if (diff.hasDiff()) {
-            screen = diff.getMarkedImage();
-            Timer.start(ACTION_NAME.CAPTURE_SCREENSHOT);
-            // Define test screenshot root
-            File testScreenRootDir = ReportContext.getTestDir();
+                screenName = System.currentTimeMillis() + ".png";
+                String screenPath = testScreenRootDir.getAbsolutePath() + "/" + screenName;
 
-            // Capture full page screenshot and resize
-            screenName = System.currentTimeMillis() + ".png";
-            String screenPath = testScreenRootDir.getAbsolutePath() + "/" + screenName;
+                BufferedImage thumbScreen = screen;
 
-            BufferedImage thumbScreen = screen;
+                if (Configuration.getInt(Parameter.BIG_SCREEN_WIDTH) != -1
+                        && Configuration.getInt(Parameter.BIG_SCREEN_HEIGHT) != -1) {
+                    resizeImg(screen, Configuration.getInt(Parameter.BIG_SCREEN_WIDTH),
+                            Configuration.getInt(Parameter.BIG_SCREEN_HEIGHT), screenPath);
+                }
 
-            if (Configuration.getInt(Parameter.BIG_SCREEN_WIDTH) != -1
-                    && Configuration.getInt(Parameter.BIG_SCREEN_HEIGHT) != -1) {
-                resizeImg(screen, Configuration.getInt(Parameter.BIG_SCREEN_WIDTH),
-                        Configuration.getInt(Parameter.BIG_SCREEN_HEIGHT), screenPath);
+                File screenshot = new File(screenPath);
+                FileUtils.touch(screenshot);
+                ImageIO.write(screen, "PNG", screenshot);
+
+                // Create comparative screenshot thumbnail
+                String thumbScreenPath = screenPath.replace(screenName, "/thumbnails/" + screenName);
+                ImageIO.write(thumbScreen, "PNG", new File(thumbScreenPath));
+                resizeImg(thumbScreen, Configuration.getInt(Parameter.SMALL_SCREEN_WIDTH),
+                        Configuration.getInt(Parameter.SMALL_SCREEN_HEIGHT), thumbScreenPath);
+
+                // Uploading comparative screenshot to Amazon S3
+                uploadToAmazonS3(screenshot);
             }
-
-            File screenshot = new File(screenPath);
-            FileUtils.touch(screenshot);
-            ImageIO.write(screen, "PNG", screenshot);
-
-            // Create screenshot thumbnail
-            String thumbScreenPath = screenPath.replace(screenName, "/thumbnails/" + screenName);
-            ImageIO.write(thumbScreen, "PNG", new File(thumbScreenPath));
-            resizeImg(thumbScreen, Configuration.getInt(Parameter.SMALL_SCREEN_WIDTH),
-                    Configuration.getInt(Parameter.SMALL_SCREEN_HEIGHT), thumbScreenPath);
-
-            // Uploading screenshot to Amazon S3
-            uploadToAmazonS3(screenshot);
-            return true;
+            else {
+                LOGGER.info("Unable to create comparative screenshot, there is no difference between images!");
+                return false;
+            }
+        } catch (IOException exception) {
+            LOGGER.error("Unable to compare screenshots due to the I/O issues!", exception);
+        } catch (NullPointerException exception) {
+            LOGGER.error("Unable to compare screenshots due to NullPointerException", exception);
+        } catch (WebDriverException exception) {
+            LOGGER.error("Unable to compare screenshots due to the WebDriverException!", exception);
+        } catch (Exception exception) {
+            LOGGER.error("Unable to compare screenshots!", exception);
+        } finally {
+            Timer.stop(ACTION_NAME.CAPTURE_SCREENSHOT);
         }
-        return false;
+        return true;
     }
 }

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -40,6 +40,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
 
 import com.qaprosoft.carina.core.foundation.commons.SpecialKeywords;
 import com.qaprosoft.carina.core.foundation.performance.ACTION_NAME;
@@ -50,6 +51,7 @@ import com.qaprosoft.carina.core.foundation.utils.Configuration.Parameter;
 import com.qaprosoft.carina.core.foundation.utils.R;
 import com.qaprosoft.carina.core.foundation.utils.messager.ZafiraMessager;
 import com.qaprosoft.carina.core.foundation.webdriver.augmenter.DriverAugmenter;
+import com.qaprosoft.carina.core.foundation.webdriver.device.Device;
 import com.qaprosoft.carina.core.foundation.webdriver.screenshot.IScreenshotRule;
 import com.qaprosoft.zafira.client.ZafiraSingleton;
 import com.qaprosoft.zafira.listener.ZafiraListener;
@@ -539,7 +541,8 @@ public class Screenshot {
             // screenShot = ImageIO.read(((TakesScreenshot) augmentedDriver).getScreenshotAs(OutputType.FILE));
             ru.yandex.qatools.ashot.Screenshot screenshot;
             if (Configuration.getPlatform().equals("ANDROID")) {
-                String pixelRatio = String.valueOf(IDriverPool.getDefaultDevice().getCapabilities().getCapability("pixelRatio"));
+                String pixelRatio = String.valueOf(((EventFiringWebDriver)augmentedDriver).getCapabilities().getCapability("pixelRatio"));
+                //                String pixelRatio = String.valueOf(IDriverPool.getDefaultDevice().getCapabilities().getCapability("pixelRatio"));
                 float dpr = Float.parseFloat(pixelRatio);
                 screenshot = (new AShot()).shootingStrategy(ShootingStrategies
                         .viewportRetina(SpecialKeywords.DEFAULT_SCROLL_TIMEOUT, SpecialKeywords.DEFAULT_HEADER, SpecialKeywords.DEFAULT_FOOTER, dpr))
@@ -709,10 +712,10 @@ public class Screenshot {
             }
         } catch (IOException exception) {
             LOGGER.error("Unable to compare screenshots due to the I/O issues!", exception);
-        } catch (NullPointerException exception) {
-            LOGGER.error("Unable to compare screenshots due to NullPointerException", exception);
         } catch (WebDriverException exception) {
             LOGGER.error("Unable to compare screenshots due to the WebDriverException!", exception);
+        } catch (NullPointerException exception) {
+            LOGGER.error("Unable to compare screenshots due to the NullPointerException", exception);
         } catch (Exception exception) {
             LOGGER.error("Unable to compare screenshots!", exception);
         } finally {

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -390,7 +390,7 @@ public class Screenshot {
      * Upload screenshot file to Amazon S3 using Zafira Client
      * @param screenshot - existing screenshot {@link File}
      */
-    private static void uploadToAmazonS3(File screenshot) {
+    public static void uploadToAmazonS3(File screenshot) {
         if (!Configuration.getBoolean(Parameter.S3_SAVE_SCREENSHOTS)) {
             LOGGER.debug("there is no sense to continue as saving screenshots onto S3 is disabled.");
             return;
@@ -467,17 +467,17 @@ public class Screenshot {
         } else if (Configuration.getDriverType().equals(SpecialKeywords.MOBILE)) {
             // Mobile web
             screenShot = ImageIO.read(((TakesScreenshot) augmentedDriver).getScreenshotAs(OutputType.FILE));
-        } else if (System.getProperty("os.name").toLowerCase().contains("mac")) {
-            // Mac OS web
-            ru.yandex.qatools.ashot.Screenshot screenshot = new AShot()
-                    .shootingStrategy(ShootingStrategies.viewportRetina(100, 0, 0, 2)).takeScreenshot(augmentedDriver);
-            screenShot = screenshot.getImage();
+        } else {
+            ru.yandex.qatools.ashot.Screenshot screenshot;
+	    if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+            	screenshot = (new AShot()).shootingStrategy(ShootingStrategies.viewportRetina(100, 0, 0, 2.0F)).takeScreenshot(augmentedDriver);
+           	screenShot = screenshot.getImage();
         } else {
             // regular web
-            ru.yandex.qatools.ashot.Screenshot screenshot = new AShot()
-                    .shootingStrategy(ShootingStrategies.viewportPasting(100)).takeScreenshot(augmentedDriver);
+            screenshot = (new AShot()).shootingStrategy(ShootingStrategies.viewportPasting(100)).takeScreenshot(augmentedDriver);
             screenShot = screenshot.getImage();
         }
+    }
 
         return screenShot;
     }


### PR DESCRIPTION
Fine-tuned the process of capturing full size screenshots on Mac OS devices, as the current problems with this mechanism, i.e. https://github.com/qaprosoft/carina/issues/653 are caused by the different DPR (Device Pixel Ratio) on biggest part of Mac OS devices, e.g. equals 2 for Retina display