### PR TITLE
Have a global configuration to skip SSL validation. this is done to skip PKIX issues

### DIFF
--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
@@ -62,6 +62,7 @@ public abstract class AbstractApiMethod extends HttpClient {
     public RequestSpecification request;
     private boolean logRequest = Configuration.getBoolean(Parameter.LOG_ALL_JSON);
     private boolean logResponse = Configuration.getBoolean(Parameter.LOG_ALL_JSON);
+    private boolean ignoreSSL = Configuration.getBoolean(Parameter.IGNORE_SSL);
 
     public AbstractApiMethod() {
         init(getClass());
@@ -176,6 +177,11 @@ public abstract class AbstractApiMethod extends HttpClient {
     }
 
     public Response callAPI() {
+
+        if(ignoreSSL) {
+            ignoreSSLCerts();
+        }
+
         if (bodyContent.length() != 0)
             request.body(bodyContent.toString());
 

--- a/carina-core/src/main/resources/config.properties
+++ b/carina-core/src/main/resources/config.properties
@@ -38,6 +38,9 @@ language=en_US
 
 env_arg_resolver=com.qaprosoft.carina.core.foundation.utils.DefaultEnvArgResolver
 env=NULL
+
+# ignore ssl
+ignore_ssl=false
 #=====================================================#
 
 #=============== Crypto configuration ================#

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -268,6 +268,9 @@ public class Configuration {
         
         VIDEO_SCALE("video_scale"),
 
+        // Ignore SSL
+        IGNORE_SSL("ignore_ssl"),
+
         // Test Execution Filter rules
         TEST_RUN_RULES("test_run_rules");
 

--- a/carina-utils/src/test/resources/config.properties
+++ b/carina-utils/src/test/resources/config.properties
@@ -15,6 +15,7 @@ ssh_username=build
 
 log_all_json=true
 tls_keysecure_location=NULL
+ignore_ssl=false
 
 jira_updater=com.qaprosoft.carina.core.foundation.jira.DefaultJiraUpdater
 jira_url=NULL


### PR DESCRIPTION
Have a global configuration to skip SSL validation. this is done to skip PKIX issues when running the test suite.

<!--- Provide a general summary of your changes in the Title above -->
Added a configuration which will be checked when calling an API to ignore SSL validation. 

<!--- Describe your changes in detail -->
Added a configuration which will be checked when calling an API to ignore SSL validation. by default, it is set to 'false'. When running tests on a URL with a self-signed https certificate this will be useful to ignore SSL validation.

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
