### PR TITLE
build-snapshot: updated logic for report generation

### DIFF
--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/AbstractTestListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/AbstractTestListener.java
@@ -212,8 +212,10 @@ public class AbstractTestListener extends TestListenerAdapter implements IDriver
         }
         
         ReportContext.renameTestDir(test);
+        ReportContext.generateTestReport();
 
         TestNamingUtil.releaseTestInfoByThread();
+        ReportContext.emptyTestDirData();
     }
 
     @Override

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -258,8 +258,6 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
 
         // handle expected skip
         Method testMethod = result.getMethod().getConstructorOrMethod().getMethod();
-        String test = TestNamingUtil.getCanonicalTestName(result);
-        ReportContext.setTestDir(test);
         if (ExpectedSkipManager.getInstance().isSkip(testMethod, result.getTestContext())) {
             skipExecution("Based on rule listed above");
         }

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -70,7 +70,6 @@ import com.qaprosoft.carina.core.foundation.utils.R;
 import com.qaprosoft.carina.core.foundation.utils.async.AsyncOperation;
 import com.qaprosoft.carina.core.foundation.utils.metadata.MetadataCollector;
 import com.qaprosoft.carina.core.foundation.utils.metadata.model.ElementsInfo;
-import com.qaprosoft.carina.core.foundation.utils.naming.TestNamingUtil;
 import com.qaprosoft.carina.core.foundation.utils.resources.I18N;
 import com.qaprosoft.carina.core.foundation.utils.resources.L10N;
 import com.qaprosoft.carina.core.foundation.utils.resources.L10Nparser;

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -70,6 +70,7 @@ import com.qaprosoft.carina.core.foundation.utils.R;
 import com.qaprosoft.carina.core.foundation.utils.async.AsyncOperation;
 import com.qaprosoft.carina.core.foundation.utils.metadata.MetadataCollector;
 import com.qaprosoft.carina.core.foundation.utils.metadata.model.ElementsInfo;
+import com.qaprosoft.carina.core.foundation.utils.naming.TestNamingUtil;
 import com.qaprosoft.carina.core.foundation.utils.resources.I18N;
 import com.qaprosoft.carina.core.foundation.utils.resources.L10N;
 import com.qaprosoft.carina.core.foundation.utils.resources.L10Nparser;
@@ -257,6 +258,8 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
 
         // handle expected skip
         Method testMethod = result.getMethod().getConstructorOrMethod().getMethod();
+        String test = TestNamingUtil.getCanonicalTestName(result);
+        ReportContext.setTestDir(test);
         if (ExpectedSkipManager.getInstance().isSkip(testMethod, result.getTestContext())) {
             skipExecution("Based on rule listed above");
         }

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -291,7 +291,14 @@ public class ReportContext {
         return testDir;
     }
     
-    public static File setCustomTestDirName(String dirName) {
+    /**
+     * Rename test directory from unique number to custom name.
+     * 
+     * @param dirName
+     * 
+     * @return test report dir
+     */
+    public synchronized static File setCustomTestDirName(String dirName) {
         isCustomTestDirName.set(Boolean.FALSE);
         File testDir = testDirectory.get();
         if(testDir == null) {
@@ -324,14 +331,6 @@ public class ReportContext {
         }
     }
 
-    /**
-     * Rename test directory from unique number to valid human readable content using test method name.
-     * 
-     * @param test
-     *            name
-     * 
-     * @return test log/screenshot folder.
-     */
     public static File renameTestDir(String test) {
         File testDir = testDirectory.get();
         if (testDir != null && !isCustomTestDirName.get()) {

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -280,6 +280,18 @@ public class ReportContext {
         testDirectory.set(testDir);
         return testDir;
     }
+    
+    public static File setTestDir(String dirName) {
+        String directory = String.format("%s/%s", getBaseDir(), dirName);
+        LOGGER.debug("Test directory will be set to : " + directory);
+        File testDir = new File(directory);
+        File thumbDir = new File(testDir.getAbsolutePath() + "/thumbnails");
+        if (!thumbDir.mkdirs()) {
+            throw new RuntimeException("Test Folder(s) not created: " + testDir.getAbsolutePath() + " and/or " + thumbDir.getAbsolutePath());
+        }
+        testDirectory.set(testDir);
+        return testDir;
+    }
 
     /**
      * Rename test directory from unique number to valid human readable content using test method name.

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -86,10 +86,6 @@ public class ReportContext {
     // Collects screenshot comments. Screenshot comments are associated using screenshot file name.
     private static Map<String, String> screenSteps = Collections.synchronizedMap(new HashMap<String, String>());
 
-    static {
-        isCustomTestDirName.set(Boolean.FALSE);
-    }
-
     public static long getRootID() {
         return rootID;
     }
@@ -333,6 +329,7 @@ public class ReportContext {
 
     public static File renameTestDir(String test) {
         File testDir = testDirectory.get();
+        initIsCustomTestDir();
         if (testDir != null && !isCustomTestDirName.get()) {
             File newTestDir = new File(String.format("%s/%s", getBaseDir(), test.replaceAll("[^a-zA-Z0-9.-]", "_")));
 
@@ -348,6 +345,12 @@ public class ReportContext {
         }
         
         return testDir;
+    }
+    
+    private static void initIsCustomTestDir() {
+        if (isCustomTestDirName.get() == null) {
+            isCustomTestDirName.set(Boolean.FALSE);
+        };
     }
 
     /**


### PR DESCRIPTION
The logic for reporting has been updated to set "suite_name - test_name" format for test data folder. 