### PR TITLE
build-snapshot: Tweak to fix checking for local builds and to handle a null exception on an empty directory

### DIFF
--- a/carina-hockeyapp/src/main/java/com/qaprosoft/hockeyapp/HockeyAppManager.java
+++ b/carina-hockeyapp/src/main/java/com/qaprosoft/hockeyapp/HockeyAppManager.java
@@ -102,10 +102,12 @@ public class HockeyAppManager {
             File file = new File(folder);
             File[] listOfFiles = file.listFiles();
 
-            for(int i = 0; i < listOfFiles.length; ++i){
-                if(listOfFiles[i].isFile() && listOfFiles[i].getName().contains(fileName)){
-                    LOGGER.info("File has been Located Locally.  File path is: " + listOfFiles[i].getAbsolutePath());
-                    fileToLocate = listOfFiles[i];
+            if (file.list() != null) {
+                for (int i = 0; i < listOfFiles.length; ++i) {
+                    if (listOfFiles[i].isFile() && fileName.contains(listOfFiles[i].getName())) {
+                        LOGGER.info("File has been Located Locally.  File path is: " + listOfFiles[i].getAbsolutePath());
+                        fileToLocate = listOfFiles[i];
+                    }
                 }
             }
         } catch (Exception ex) {


### PR DESCRIPTION
Summary:

It was found that the local check being completed was reversed and never passing, so we've corrected it.  There was also a tweak put in to hand a null exception if the download directory is a new directory with no files in it.
