### PR TITLE
build-snapshot: Fixed logs issue in debug mode for ThreadLogAppender.append(ThreadLogAppender.java:56)

### DIFF
--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -337,8 +337,8 @@ public class ReportContext {
                 // close ThreadLogAppender resources before renaming
                 closeThreadLogAppender();
                 testDir.renameTo(newTestDir);
-                LOGGER.debug("Test directory will be set to : " + newTestDir);
-                testDirectory.set(newTestDir);            
+                testDirectory.set(newTestDir);    
+                LOGGER.debug("Test directory is set to : " + newTestDir);
             }
         } else {
             LOGGER.error("Unexpected case with absence of test.log for '" + test + "'");


### PR DESCRIPTION
Fixed the issue when we are trying to append logs in non-existing file. Changed logic to set `testDirectory.set(newTestDir)` firstly and then perform `LOGGER.debug('message')`
