### PR TITLE
improved amazon aws-java-sdk dependencies, download only aws-java-sdk-s3

### DIFF
--- a/carina-aws-s3/pom.xml
+++ b/carina-aws-s3/pom.xml
@@ -39,7 +39,7 @@
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
+			<artifactId>aws-java-sdk-s3</artifactId>
 		</dependency>
 
 		<!-- Test utilities -->

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk</artifactId>
+                <artifactId>aws-java-sdk-s3</artifactId>
                 <version>${aws-java-sdk.version}</version>
 		<exclusions>
 			<exclusion>
@@ -541,6 +541,10 @@
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
+                    </exclusion>
+                     <exclusion>
+                        <groupId>com.amazonaws</groupId>
+						<artifactId>aws-java-sdk</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,14 @@
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
 			</exclusion>
+			<exclusion>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-kms</artifactId>
+			</exclusion>
+			<exclusion>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>jmespath-java</artifactId>
+			</exclusion>
 		</exclusions>
             </dependency>
             <!-- Test utilities -->
@@ -542,7 +550,7 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
-                     <exclusion>
+                    <exclusion>
                         <groupId>com.amazonaws</groupId>
 						<artifactId>aws-java-sdk</artifactId>
                     </exclusion>


### PR DESCRIPTION
1. Download only aws-java-sdk-s3
2. Exclude aws-java-sdk from zafira-client
3. aws-java-sdk-kms and jmespath-java are excluded