### PR TITLE
build-snapshot: issues_794: browsermob_ports_range feature was introduced

### DIFF
--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
@@ -45,7 +45,7 @@ public final class ProxyPool {
 		if (!Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).isEmpty()) {
 			try {
 				String[] ports = Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).split(":");
-				for (int i = Integer.valueOf(ports[0]); i < Integer.valueOf(ports[1]); i++) {
+				for (int i = Integer.valueOf(ports[0]); i <= Integer.valueOf(ports[1]); i++) {
 					proxyPortsFromRange.put(i, true);
 				}
 			} catch (Exception e) {
@@ -205,9 +205,12 @@ public final class ProxyPool {
     }
     
     private static void setProxyPortToAvailable(long threadId) {
-    	if(proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
-    		proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
-    	}
+		if (proxyPortsByThread.get(threadId) != null) {
+			if (proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
+				proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
+				LOGGER.info("BrowserMob proxy port " + proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) + " was set to available state");
+			}
+		}
     }
 
     // https://github.com/lightbody/browsermob-proxy/issues/264 'started' flag is not set to false after stopping BrowserMobProxyServer

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
@@ -208,9 +208,9 @@ public final class ProxyPool {
     private static void setProxyPortToAvailable(long threadId) {
 		if (proxyPortsByThread.get(threadId) != null) {
 			if (proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
+				LOGGER.info("Setting BrowserMob proxy port " + proxyPortsByThread.get(threadId) + " to available state");
 				proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
 				proxyPortsByThread.remove(threadId);
-				LOGGER.info("BrowserMob proxy port " + proxyPortsByThread.get(threadId) + " was set to available state");
 			}
 		}
     }

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
@@ -148,6 +148,7 @@ public final class ProxyPool {
 		else if (!Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).isEmpty()) {
 			for (Map.Entry<Integer, Boolean> pair : proxyPortsFromRange.entrySet()) {
 				if (pair.getValue()) {
+					LOGGER.info("Making BrowserMob proxy port busy: " + pair.getKey());
 					pair.setValue(false);
 					return pair.getKey().intValue();
 				}
@@ -166,11 +167,11 @@ public final class ProxyPool {
      * @return BrowserMobProxy
      * 
      */
-    public static BrowserMobProxy startProxy() {
+    public static synchronized BrowserMobProxy startProxy() {
         return startProxy(getProxyPortFromConfig());
     }
     
-    public static BrowserMobProxy startProxy(int proxyPort) {
+    public static synchronized BrowserMobProxy startProxy(int proxyPort) {
         if (!Configuration.getBoolean(Parameter.BROWSERMOB_PROXY)) {
             LOGGER.debug("Proxy is disabled.");
             return null;
@@ -208,7 +209,7 @@ public final class ProxyPool {
 		if (proxyPortsByThread.get(threadId) != null) {
 			if (proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
 				proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
-				LOGGER.info("BrowserMob proxy port " + proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) + " was set to available state");
+				LOGGER.info("BrowserMob proxy port " + proxyPortsByThread.get(threadId) + " was set to available state");
 			}
 		}
     }

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
@@ -16,6 +16,7 @@
 package com.qaprosoft.carina.browsermobproxy;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.log4j.Logger;
@@ -33,7 +34,26 @@ import net.lightbody.bmp.BrowserMobProxyServer;
 public final class ProxyPool {
     protected static final Logger LOGGER = Logger.getLogger(ProxyPool.class);
     private static ConcurrentHashMap<Long, Integer> proxyPortsByThread = new ConcurrentHashMap<Long, Integer>();
+    
+    /**
+     * map for storing of available ports range and their availability
+     */
+    private static ConcurrentHashMap<Integer, Boolean> proxyPortsFromRange = new ConcurrentHashMap<Integer, Boolean>();
 
+    
+	static {
+		if (!Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).isEmpty()) {
+			try {
+				String[] ports = Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).split(":");
+				for (int i = Integer.valueOf(ports[0]); i < Integer.valueOf(ports[1]); i++) {
+					proxyPortsFromRange.put(i, true);
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Please specify BROWSERMOB_PORTS_RANGE in format 'port_from:port_to'");
+			}
+		}
+	}
+    
     // ------------------------- BOWSERMOB PROXY ---------------------
     // TODO: investigate possibility to return interface to support JettyProxy
     /**
@@ -73,7 +93,7 @@ public final class ProxyPool {
             LOGGER.warn("Set http/https proxy settings only to use with BrowserMobProxy host: " + currentIP + "; port: " + proxyPortsByThread.get(threadId));
             
             R.CONFIG.put("proxy_host", currentIP);
-            R.CONFIG.put("proxy_port", port.toString());
+            R.CONFIG.put(Parameter.PROXY_PORT.getKey(), port.toString());
             
             R.CONFIG.put("proxy_protocols", "http,https");
 
@@ -117,6 +137,27 @@ public final class ProxyPool {
     // ------------------------- BOWSERMOB PROXY ---------------------
     
     private static final ConcurrentHashMap<Long, BrowserMobProxy> proxies = new ConcurrentHashMap<Long, BrowserMobProxy>();
+    
+    /**
+     * Checking whether BROWSERMOB_PORT is declared. then it will be used as port for browsermob proxy
+     * Otherwise first available port from BROWSERMOB_PORTS_RANGE will be used
+     */
+	public static int getProxyPortFromConfig() {
+		if (!Configuration.get(Parameter.BROWSERMOB_PORT).isEmpty())
+			return Configuration.getInt(Parameter.BROWSERMOB_PORT);
+		else if (!Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).isEmpty()) {
+			for (Map.Entry<Integer, Boolean> pair : proxyPortsFromRange.entrySet()) {
+				if (pair.getValue()) {
+					pair.setValue(false);
+					return pair.getKey().intValue();
+				}
+			}
+			throw new RuntimeException(
+					"All ports from Parameter.BROWSERMOB_PORTS_RANGE are currently busy. Please change execution thread count");
+		}
+		throw new RuntimeException(
+				"Neither Parameter.BROWSERMOB_PORT nor Parameter.BROWSERMOB_PORTS_RANGE are specified!");
+	}
 
     // TODO: investigate possibility to return interface to support JettyProxy
     /**
@@ -126,7 +167,7 @@ public final class ProxyPool {
      * 
      */
     public static BrowserMobProxy startProxy() {
-        return startProxy(Configuration.getInt(Parameter.BROWSERMOB_PORT));
+        return startProxy(getProxyPortFromConfig());
     }
     
     public static BrowserMobProxy startProxy(int proxyPort) {
@@ -162,6 +203,12 @@ public final class ProxyPool {
 
         return proxy;
     }
+    
+    private static void setProxyPortToAvailable(long threadId) {
+    	if(proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
+    		proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
+    	}
+    }
 
     // https://github.com/lightbody/browsermob-proxy/issues/264 'started' flag is not set to false after stopping BrowserMobProxyServer
     // Due to the above issue we can't control BrowserMob isRunning state and shouldn't stop it
@@ -192,6 +239,7 @@ public final class ProxyPool {
     private static void stopProxyByThread(long threadId) {
         LOGGER.debug("stopProxy starting...");
         if (proxies.containsKey(threadId)) {
+        	setProxyPortToAvailable(threadId);
             BrowserMobProxy proxy = proxies.get(threadId);
             if (proxy != null) {
                 LOGGER.debug("Found registered proxy by thread: " + threadId);
@@ -233,7 +281,7 @@ public final class ProxyPool {
         return proxy;
     }
 
-    public static int getProxyPort() {
+    public static int getProxyPortFromThread() {
         int port = 0;
         long threadId = Thread.currentThread().getId();
         if (proxyPortsByThread.containsKey(threadId)) {

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
@@ -209,6 +209,7 @@ public final class ProxyPool {
 		if (proxyPortsByThread.get(threadId) != null) {
 			if (proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
 				proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
+				proxyPortsByThread.remove(threadId);
 				LOGGER.info("BrowserMob proxy port " + proxyPortsByThread.get(threadId) + " was set to available state");
 			}
 		}

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserMobPortsRangeTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserMobPortsRangeTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2013-2019 QaProSoft (http://www.qaprosoft.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.qaprosoft.carina.browsermobproxy;
+
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.qaprosoft.carina.core.foundation.utils.R;
+import com.qaprosoft.carina.proxy.SystemProxy;
+
+import net.lightbody.bmp.BrowserMobProxy;
+
+public class BrowserMobPortsRangeTest {
+    protected static final Logger LOGGER = Logger.getLogger(BrowserMobPortsRangeTest.class);
+    private static String header = "my_header";
+    private static String headerValue = "my_value";
+
+    @BeforeClass(alwaysRun = true)
+    public void beforeClass() {
+        R.CONFIG.put("core_log_level", "DEBUG");
+        R.CONFIG.put("browsermob_proxy", "true");
+        R.CONFIG.put("proxy_set_to_system", "false");
+        R.CONFIG.put("browsermob_port", "NULL");
+        R.CONFIG.put("browsermob_ports_range", "0:0");
+        R.CONFIG.put("browsermob_disabled_mitm", "false");
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() {
+        ProxyPool.stopAllProxies();
+    }
+
+    @Test
+    public void testPortsRange() {
+        initialize();
+        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
+    }
+
+    private void initialize() {
+        ProxyPool.setupBrowserMobProxy();
+        SystemProxy.setupProxy();
+
+        BrowserMobProxy proxy = ProxyPool.getProxy();
+        proxy.addHeader(header, headerValue);
+    }
+
+}

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserMobTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserMobTest.java
@@ -64,6 +64,15 @@ public class BrowserMobTest {
         initialize();
         Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
     }
+    
+    @Test
+    public void testPortsRange() {
+        R.CONFIG.put("proxy_set_to_system", "false");
+        R.CONFIG.put("browsermob_port", "NULL");
+        R.CONFIG.put("browsermob_ports_range", "0:0");
+        initialize();
+        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
+    }
 
     @Test
     public void testBrowserModProxySystemIntegration() {

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserMobTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserMobTest.java
@@ -64,15 +64,6 @@ public class BrowserMobTest {
         initialize();
         Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
     }
-    
-    @Test
-    public void testPortsRange() {
-        R.CONFIG.put("proxy_set_to_system", "false");
-        R.CONFIG.put("browsermob_port", "NULL");
-        R.CONFIG.put("browsermob_ports_range", "0:0");
-        initialize();
-        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
-    }
 
     @Test
     public void testBrowserModProxySystemIntegration() {

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/proxy/SystemProxyTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/proxy/SystemProxyTest.java
@@ -20,6 +20,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.qaprosoft.carina.core.foundation.utils.Configuration.Parameter;
 import com.qaprosoft.carina.core.foundation.utils.R;
 
 public class SystemProxyTest {
@@ -33,7 +34,7 @@ public class SystemProxyTest {
         R.CONFIG.put("browsermob_proxy", "false");
         R.CONFIG.put("proxy_set_to_system", "true");
         R.CONFIG.put("proxy_host", host);
-        R.CONFIG.put("proxy_port", port);
+        R.CONFIG.put(Parameter.PROXY_PORT.getKey(), port);
 
     }
 

--- a/carina-proxy/src/test/resources/config.properties
+++ b/carina-proxy/src/test/resources/config.properties
@@ -8,5 +8,6 @@ max_log_file_size=150
 browsermob_proxy=true
 browsermob_host=NULL
 browsermob_port=0
+browsermob_ports_range=NULL
 proxy_set_to_system=true
 browsermob_disabled_mitm=false

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -94,6 +94,8 @@ public class Configuration {
 
         BROWSERMOB_PORT("browsermob_port"),
         
+        BROWSERMOB_PORTS_RANGE("browsermob_ports_range"),
+        
         BROWSERMOB_MITM("browsermob_disabled_mitm"),
 
         PROXY_SET_TO_SYSTEM("proxy_set_to_system"),

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
@@ -370,15 +370,15 @@ public interface IDriverPool {
                 // moved proxy start logic here since device will be initialized
                 // here only
                 if (Configuration.getBoolean(Parameter.BROWSERMOB_PROXY)) {
-                    int proxyPort = ProxyPool.getProxyPortFromConfig();
                     if (!device.isNull()) {
+                    	int proxyPort;
                         try {
                             proxyPort = Integer.parseInt(device.getProxyPort());
                         } catch (NumberFormatException e) {
                             // use default from _config.properties. Use-case for
                             // iOS devices which doesn't have proxy_port as part
                             // of capabilities
-//                            proxyPort = Configuration.getInt(Parameter.BROWSERMOB_PORT);
+                            proxyPort = ProxyPool.getProxyPortFromConfig();
                         }
                         ProxyPool.startProxy(proxyPort);
                     }

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
@@ -370,7 +370,7 @@ public interface IDriverPool {
                 // moved proxy start logic here since device will be initialized
                 // here only
                 if (Configuration.getBoolean(Parameter.BROWSERMOB_PROXY)) {
-                    int proxyPort = Configuration.getInt(Parameter.BROWSERMOB_PORT);
+                    int proxyPort = ProxyPool.getProxyPortFromConfig();
                     if (!device.isNull()) {
                         try {
                             proxyPort = Integer.parseInt(device.getProxyPort());
@@ -378,7 +378,7 @@ public interface IDriverPool {
                             // use default from _config.properties. Use-case for
                             // iOS devices which doesn't have proxy_port as part
                             // of capabilities
-                            proxyPort = Configuration.getInt(Parameter.BROWSERMOB_PORT);
+//                            proxyPort = Configuration.getInt(Parameter.BROWSERMOB_PORT);
                         }
                         ProxyPool.startProxy(proxyPort);
                     }

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/AbstractCapabilities.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/AbstractCapabilities.java
@@ -100,7 +100,7 @@ public abstract class AbstractCapabilities {
         String proxyHost = Configuration.get(Parameter.PROXY_HOST);
         String proxyPort = Configuration.get(Parameter.PROXY_PORT);
         if (Configuration.get(Parameter.BROWSERMOB_PROXY).equals("true")) {
-            proxyPort = Integer.toString(ProxyPool.getProxyPort());
+            proxyPort = Integer.toString(ProxyPool.getProxyPortFromThread());
         }
         List<String> protocols = Arrays.asList(Configuration.get(Parameter.PROXY_PROTOCOLS).split("[\\s,]+"));
 

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/MobileFactory.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/MobileFactory.java
@@ -315,8 +315,8 @@ public class MobileFactory extends AbstractFactory {
                 if (cap.containsKey("vnc")) {
                     remoteDevice.setVnc((String) cap.get("vnc"));
                 }
-                if (cap.containsKey("proxy_port")) {
-                    remoteDevice.setProxyPort(String.valueOf(cap.get("proxy_port")));
+                if (cap.containsKey(Parameter.PROXY_PORT.getKey())) {
+                    remoteDevice.setProxyPort(String.valueOf(cap.get(Parameter.PROXY_PORT.getKey())));
                 }
                 
                 if (cap.containsKey("remoteURL")) {

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/device/Device.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/device/Device.java
@@ -132,8 +132,8 @@ public class Device extends RemoteDevice implements IDriverPool {
         setUdid(deviceUdid);
         
         String proxyPort = R.CONFIG.get(SpecialKeywords.MOBILE_PROXY_PORT);
-        if (capabilities.getCapability("proxy_port") != null) {
-            proxyPort = capabilities.getCapability("proxy_port").toString();
+        if (capabilities.getCapability(Parameter.PROXY_PORT.getKey()) != null) {
+            proxyPort = capabilities.getCapability(Parameter.PROXY_PORT.getKey()).toString();
         }
 
         setProxyPort(proxyPort);


### PR DESCRIPTION
Related issue: https://github.com/qaprosoft/carina/issues/794

We need this functionality to enable tests with proxy execution in multi-threaded mode. When entire infrastructure is distributed between several selenium boxes

to enable the feature next properties should be set:
-- not to use predefined single port
browsermob_port=NULL
-- range of ports that could be used instead
browsermob_ports_range=55881:55884

Firstly logic checks whether browsermob_port is specified. If true than it will be used for proxy settings. Otherwise it checks whether ports range is predefined.
Then ports are taken from the range one by one for each new test thread