### PR TITLE
build-snapshot: Add method to return versionName from system dump

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/IAndroidUtils.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/IAndroidUtils.java
@@ -876,6 +876,22 @@ public interface IAndroidUtils extends IMobileUtils {
     }
 
     /**
+     * This method provides app's version name for the app that is already installed to
+     * devices, based on its package name.
+     *
+     * In order to do that we search for "versionName" parameter in system dump.
+     *
+     * Ex. "versionCode" returns 11200050, "versionName" returns 11.2.0
+     */
+    default public String getAppVersionName(String packageName){
+        String command = "dumpsys package ".concat(packageName);
+        String output = this.executeShell(command);
+        String versionName = StringUtils.substringBetween(output, "versionName=", "\n");
+        LOGGER.info(String.format("Version name for '%s' package name is %s", packageName, versionName));
+        return versionName;
+    }
+
+    /**
      * Method to reset test application.
      * 
      * App's settings will be reset. User will be logged out. Application will be


### PR DESCRIPTION
Adding a method to allow users to return the value of installed package versionName. This is essentially a short-form version number of the app's package typically shown within the app itself which can be used for UI validation and passing as needed.

Ex. An installed package's versionCode returns 11200050. The package's versionName returns 11.2.0

This example of the differences is supplied in the method's associated comment.