### PR TITLE
build-snapshot: Changed url protocol htpp to https for spring dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <repository>
             <id>springio-plugins-release</id>
             <name>Spring Plugins</name>
-            <url>http://repo.spring.io/plugins-release/</url>
+            <url>https://repo.spring.io/plugins-release/</url>
         </repository>
     </repositories>
     <profiles>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed line 122 of pom.xml

<!--- Describe your changes in details -->
Trying to build and compile carina it fails due to access denied to:
 http://repo.spring.io/plugins-release/. Changed to https
<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
