### PR TITLE
fix eclipse workspace property name

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -60,7 +60,7 @@ mvn clean eclipse:eclipse
 ```
 By executing this command, Maven should resolve all dependencies, downloading the required libraries to your local repository and generating the Eclipse classpath. Before importing a new project to Eclipse, you should link your IDE to your Maven repository by executing the following task:
 ```
-mvn -Dworkspace=<path_to_workspace> eclipse:configure-workspace
+mvn -Declipse.workspace=<path_to_workspace> eclipse:configure-workspace
 ```
 Here you need to specify the absolute path to the Eclipse workspace. After that, restart Eclipse IDE. Now you can import generated projects such as "Existing Java Project" into Eclipse IDE.
 


### PR DESCRIPTION
a fix for eclipse workspace property name.
with just -Dworkspace I got the following error:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-eclipse-plugin:2.10:configure-workspace (default-cli) on project carina: The parameters 'workspace' for goal org.apache.maven.plugins:maven-eclipse-p
> lugin:2.10:configure-workspace are missing or invalid -> [Help 1]

the correct name of this property is `eclipse.workspace`