### PR TITLE
build-snapshot: Tweak here is flipping the search order to the most recently updated app in AppCenter

### DIFF
--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -93,15 +93,9 @@ public class AppCenterManager {
 
         String buildToDownload = scanAppForBuild(getAppId(appName, platformName), buildType, version);
 
-        if (!buildToDownload.contains("api")) {
-            buildToDownload = new StringBuilder(buildToDownload).insert(buildToDownload.indexOf("/apps"), "/api/2").toString()
-                    + "?format=" + returnProperPlatformExtension(platformName);
-        }
-
         String fileName = folder + "/" + createFileName(appName, buildType, platformName);
         File fileToLocate = null;
 
-        //TODO:  Make sure to use the correct paths here
         try {
             File file = new File(folder);
             File[] listOfFiles = file.listFiles();
@@ -237,7 +231,7 @@ public class AppCenterManager {
             if (buildList.size() > 0) {
                 int buildLimiter = 0;
                 for (JsonNode build : buildList) {
-                    
+
                     buildLimiter += 1;
                     if (buildLimiter >=50) {
                         break;

--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -235,7 +235,14 @@ public class AppCenterManager {
             LOGGER.debug("Available Builds JSON: " + buildList);
 
             if (buildList.size() > 0) {
+                int buildLimiter = 0;
                 for (JsonNode build : buildList) {
+                    
+                    buildLimiter += 1;
+                    if (buildLimiter >=50) {
+                        break;
+                    }
+
                     String latestBuildNumber = build.get("id").asText();
                     versionShort = build.get("short_version").asText();
                     versionLong = build.get("version").asText();

--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -203,7 +203,7 @@ public class AppCenterManager {
         if (!appMap.isEmpty()) {
             return appMap.entrySet()
                     .stream()
-                    .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                    .sorted(Map.Entry.comparingByValue(Comparator.naturalOrder()))
                     .collect(Collectors.toMap(
                             Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
         }


### PR DESCRIPTION
The main change here is flipping the order that is scanned through in AppCenter, the flip of the order is done by the updated_at field allowing us to start with the most recently updated app and then work our way backwards.