### PR TITLE
Resolves #965 handling of ALREADY_FAILED_BY_KNOWN_BUG SkipExceptions

### DIFF
--- a/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
+++ b/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
@@ -118,6 +118,7 @@ public class SpecialKeywords {
     public static final String SKIPPED = "SKIPPED";
 
     public static final String ALREADY_PASSED = "ALREADY_PASSED";
+    public static final String ALREADY_FAILED_BY_KNOWN_BUG = "ALREADY_FAILED_BY_KNOWN_BUG";
     public static final String SKIP_EXECUTION = "SKIP_EXECUTION";
 
     public static final String ZAFIRA_PROJECT = "zafira_project";

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/AbstractTestListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/AbstractTestListener.java
@@ -161,7 +161,7 @@ public class AbstractTestListener extends TestListenerAdapter implements IDriver
         return errorMessage;
     }
 
-    private void skipAlreadyPassedItem(ITestResult result, Messager messager) {
+    private void skipTestItem(ITestResult result, Messager messager) {
         String test = TestNamingUtil.getCanonicalTestName(result);
         String deviceName = getDeviceName();
         messager.info(deviceName, test, DateUtils.now());
@@ -340,8 +340,8 @@ public class AbstractTestListener extends TestListenerAdapter implements IDriver
         if (result.getThrowable() != null && result.getThrowable().getMessage() != null
                 && result.getThrowable().getMessage().startsWith(SpecialKeywords.ALREADY_PASSED)) {
             // [VD] it is prohibited to release TestInfoByThread in this place.!
-            skipAlreadyPassedItem(result, Messager.TEST_SKIPPED_AS_ALREADY_PASSED);
-            // [VD] no need to reset as we TestNG doesn't launch retryAnalyzer so we don't increment it on ALREADY_PASSDE skip exception
+            skipTestItem(result, Messager.TEST_SKIPPED_AS_ALREADY_PASSED);
+            // [VD] no need to reset as TestNG doesn't launch retryAnalyzer so we don't increment it on ALREADY_PASSED skip exception
             return;
         }
         
@@ -349,6 +349,13 @@ public class AbstractTestListener extends TestListenerAdapter implements IDriver
         if (result.getThrowable() != null && result.getThrowable().getMessage() != null
                 && result.getThrowable().getMessage().startsWith(SpecialKeywords.SKIP_EXECUTION)) {
             // [VD] it is prohibited to release TestInfoByThread in this place.!
+            return;
+        }
+        
+        // handle Zafira already failed by known bug exception for re-run and do nothing
+        if (result.getThrowable() != null && result.getThrowable().getMessage() != null
+                && result.getThrowable().getMessage().startsWith(SpecialKeywords.ALREADY_FAILED_BY_KNOWN_BUG)) {
+            skipTestItem(result, Messager.TEST_SKIPPED_AS_ALREADY_FAILED_BY_BUG);
             return;
         }
         

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Messager.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Messager.java
@@ -38,6 +38,8 @@ public enum Messager implements IMessager {
 
     TEST_SKIPPED_AS_ALREADY_PASSED("%s TEST [%s] SKIPPED as already passed in previous run at [%s]"),
 
+    TEST_SKIPPED_AS_ALREADY_FAILED_BY_BUG("%s TEST [%s] SKIPPED as already failed because of known issue at [%s]"),
+
     TEST_FAILED("%s TEST [%s] FAILED at [%s] - %s"),
 
     RETRY_FAILED("%s TEST [%s] RETRY %s of %s FAILED - %s"),

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <selenium.version>3.141.59</selenium.version>
         <appium.version>7.2.0</appium.version>
         <!-- Qaprosoft integrations -->
-        <zafira-client.version>4.1.68</zafira-client.version>
+        <zafira-client.version>4.0.53-SNAPSHOT</zafira-client.version>
         <alice-client.version>1.1.0</alice-client.version>
         <!-- Others -->
         <aws-java-sdk.version>1.11.386</aws-java-sdk.version>


### PR DESCRIPTION
965 description:
That will remove redundant test results in final testNG report.
Logic should work similarly with ALREADY_PASSED skipped tests processing.
Related to zafira-client PR: qaprosoft/zafira-client#20