### PR TITLE
build-snapshot: Zebrunner listener was added instead of ZafiraListener

### DIFF
--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/AbstractTest.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/AbstractTest.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import com.nordstrom.automation.testng.LinkedListeners;
 import com.qaprosoft.carina.core.foundation.listeners.CarinaListener;
 import com.qaprosoft.zafira.listener.ZafiraListener;
+import com.qaprosoft.zafira.listener.ZebrunnerListener;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.SkipException;
@@ -45,7 +46,7 @@ import com.qaprosoft.carina.core.foundation.utils.naming.TestNamingUtil;
 
 // https://github.com/qaprosoft/carina/issues/951
 // moved CarinaListener to META-INF/services/org.testng.ITestNGListener to implicitly register it for any Carina based test
-@LinkedListeners({CarinaListener.class, ZafiraListener.class})
+@LinkedListeners({CarinaListener.class, ZebrunnerListener.class})
 public abstract class AbstractTest implements ICustomTypePageFactory, ITestCases {
 
     protected static final long EXPLICIT_TIMEOUT = Configuration.getLong(Parameter.EXPLICIT_TIMEOUT);

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <selenium.version>3.141.59</selenium.version>
         <appium.version>7.2.0</appium.version>
         <!-- Qaprosoft integrations -->
-        <zafira-client.version>4.0.56-SNAPSHOT</zafira-client.version>
+        <zafira-client.version>4.0.58-SNAPSHOT</zafira-client.version>
         <alice-client.version>1.1.0</alice-client.version>
         <!-- Others -->
         <aws-java-sdk.version>1.11.386</aws-java-sdk.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
