### PR TITLE
#988: added default log4j apenders for build process

### DIFF
--- a/carina-utils/src/main/resources/log4j.properties
+++ b/carina-utils/src/main/resources/log4j.properties
@@ -4,13 +4,25 @@
 #
 #------------------------------------------------------------------------------
 
-log4j.rootCategory=INFO
+log4j.rootCategory=INFO, C, F, ThreadLogAppender
 
 #------------------------------------------------------------------------------
-#
 #  The following properties configure the console (stdout) appender.
-#
 #------------------------------------------------------------------------------
 log4j.appender.C = org.apache.log4j.ConsoleAppender
 log4j.appender.C.layout = org.apache.log4j.PatternLayout
 log4j.appender.C.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%t%X{threadId}] [%p] %X{device}%m%n
+
+log4j.logger.com.qaprosoft.carina.core=INFO
+log4j.logger.com.qaprosoft.carina.core.foundation.dataprovider=warn
+log4j.appender.ThreadLogAppender=com.qaprosoft.carina.core.foundation.log.ThreadLogAppender
+
+#------------------------------------------------------------------------------
+#  The following properties configure the Daily Rolling File appender.
+#------------------------------------------------------------------------------
+log4j.appender.F = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.F.File = target/logs/test.log
+log4j.appender.F.Append = true
+log4j.appender.F.DatePattern = '.'yyy-MM-dd
+log4j.appender.F.layout = org.apache.log4j.PatternLayout
+log4j.appender.F.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
