### PR TITLE
build-snapshot: Adding in ACCEPT_INSECURE_CERTS for Chrome Capabilities

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
@@ -33,6 +33,7 @@ public class ChromeCapabilities extends AbstractCapabilities {
         capabilities.setCapability("chrome.switches", Arrays.asList("--start-maximized", "--ignore-ssl-errors"));
         capabilities.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
         capabilities.setCapability(CapabilityType.TAKES_SCREENSHOT, false);
+        capabilities.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
         LOGGER.debug("chrome caps: " + capabilities);
         return capabilities;
     }


### PR DESCRIPTION
When using Chrome 78 and above and adding BMP with MITM into the mix it is seen that an insecure warning message appears by default.  By adding in this capability it will allow us to see if it resolves that message in this snapshot.