### PR TITLE
build-snapshot: WinAppDriver support; PageOpeningStrategy was introduced

### DIFF
--- a/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
+++ b/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
@@ -100,6 +100,7 @@ public class SpecialKeywords {
     public static final String ANDROID = "Android";
     public static final String IOS = "IOS";
     public static final String MAC = "MAC";
+    public static final String WINDOWS = "Windows";
     public static final String TVOS = "TVOS";
 
     public static final String NATIVE = "native";

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -114,7 +114,9 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
     static {
         try {
             // Add shutdown hook
-            Runtime.getRuntime().addShutdownHook(new ShutdownHook());
+            if (!Configuration.getBoolean(Parameter.FORCLY_DISABLE_DRIVER_QUIT)) {
+                Runtime.getRuntime().addShutdownHook(new ShutdownHook());
+            }
             // Set log4j properties
             URL log4jUrl = ClassLoader.getSystemResource("carina-log4j.properties");
             LOGGER.debug("carina-log4j.properties: " + log4jUrl);
@@ -327,7 +329,9 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
             LOGGER.debug("Test result is : " + result.getStatus());
             // result status == 2 means failure, status == 3 means skip. We need to quit driver anyway for failure and skip
             if ((automaticDriversCleanup && !hasDependencies(result)) || result.getStatus() == 2 || result.getStatus() == 3) {
-                quitDrivers(Phase.BEFORE_METHOD, Phase.METHOD);
+                if (!Configuration.getBoolean(Parameter.FORCLY_DISABLE_DRIVER_QUIT)) {
+                    quitDrivers(Phase.BEFORE_METHOD, Phase.METHOD);
+                }
             }
 
             // TODO: improve later removing duplicates with AbstractTestListener

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -114,7 +114,7 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
     static {
         try {
             // Add shutdown hook
-            if (!Configuration.getBoolean(Parameter.FORCLY_DISABLE_DRIVER_QUIT)) {
+            if (!Configuration.getBoolean(Parameter.FORCIBLY_DISABLE_DRIVER_QUIT)) {
                 Runtime.getRuntime().addShutdownHook(new ShutdownHook());
             }
             // Set log4j properties
@@ -329,7 +329,7 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
             LOGGER.debug("Test result is : " + result.getStatus());
             // result status == 2 means failure, status == 3 means skip. We need to quit driver anyway for failure and skip
             if ((automaticDriversCleanup && !hasDependencies(result)) || result.getStatus() == 2 || result.getStatus() == 3) {
-                if (!Configuration.getBoolean(Parameter.FORCLY_DISABLE_DRIVER_QUIT)) {
+                if (!Configuration.getBoolean(Parameter.FORCIBLY_DISABLE_DRIVER_QUIT)) {
                     quitDrivers(Phase.BEFORE_METHOD, Phase.METHOD);
                 }
             }

--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -114,9 +114,7 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
     static {
         try {
             // Add shutdown hook
-            if (!Configuration.getBoolean(Parameter.FORCIBLY_DISABLE_DRIVER_QUIT)) {
-                Runtime.getRuntime().addShutdownHook(new ShutdownHook());
-            }
+            Runtime.getRuntime().addShutdownHook(new ShutdownHook());
             // Set log4j properties
             URL log4jUrl = ClassLoader.getSystemResource("carina-log4j.properties");
             LOGGER.debug("carina-log4j.properties: " + log4jUrl);
@@ -1019,7 +1017,9 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
         @Override
         public void run() {
             LOGGER.debug("Running shutdown hook");
-            quitAllDriversOnHook();
+            if (!Configuration.getBoolean(Parameter.FORCIBLY_DISABLE_DRIVER_QUIT)) {
+                quitAllDriversOnHook();
+            }
             generateMetadata();
         }
 

--- a/carina-core/src/main/resources/config.properties
+++ b/carina-core/src/main/resources/config.properties
@@ -65,7 +65,7 @@ custom_artifacts_folder=NULL
 scroll_to_element_y_offset=120
 element_loading_strategy=BY_PRESENCE_OR_VISIBILITY
 page_opening_strategy=BY_URL_AND_ELEMENT
-forcly_disable_driver_quit=false
+forcibly_disable_driver_quit=false
 #=====================================================#
 
 #================ Report configuration ===============#

--- a/carina-core/src/main/resources/config.properties
+++ b/carina-core/src/main/resources/config.properties
@@ -64,6 +64,8 @@ auto_download_folder=NULL
 custom_artifacts_folder=NULL
 scroll_to_element_y_offset=120
 element_loading_strategy=BY_PRESENCE_OR_VISIBILITY
+page_opening_strategy=BY_URL_AND_ELEMENT
+forcly_disable_driver_quit=false
 #=====================================================#
 
 #================ Report configuration ===============#

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -199,6 +199,10 @@ public class Configuration {
         TEST_NAMING_PATTERN("test_naming_pattern"),
         
         ELEMENT_LOADING_STRATEGY("element_loading_strategy"),
+        
+        PAGE_OPENING_STRATEGY("page_opening_strategy"),
+        
+        FORCLY_DISABLE_DRIVER_QUIT("forcly_disable_driver_quit"),
 
         // TestRail
         TESTRAIL_RUN_NAME("testrail_run_name"),
@@ -477,6 +481,11 @@ public class Configuration {
             LOGGER.debug("Detected MOBILE driver_type by platform: " + platform);
             return SpecialKeywords.MOBILE;
         }
+        
+        if (SpecialKeywords.WINDOWS.equalsIgnoreCase(platform)) {
+            LOGGER.debug("Detected WINDOWS driver_type by platform: " + platform);
+            return SpecialKeywords.WINDOWS;
+        }
 
         LOGGER.debug("Return default DESKTOP driver_type");
         return SpecialKeywords.DESKTOP;
@@ -501,6 +510,11 @@ public class Configuration {
         if (SpecialKeywords.ANDROID.equalsIgnoreCase(platform) || SpecialKeywords.IOS.equalsIgnoreCase(platform) || SpecialKeywords.TVOS.equalsIgnoreCase(platform)) {
             LOGGER.debug("Detected MOBILE driver_type by platform: " + platform);
             return SpecialKeywords.MOBILE;
+        }
+        
+        if (SpecialKeywords.WINDOWS.equalsIgnoreCase(platform)) {
+            LOGGER.debug("Detected WINDOWS driver_type by platform: " + platform);
+            return SpecialKeywords.WINDOWS;
         }
 
         // handle use-case when we provide only uuid object among desired capabilities

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -202,7 +202,7 @@ public class Configuration {
         
         PAGE_OPENING_STRATEGY("page_opening_strategy"),
         
-        FORCLY_DISABLE_DRIVER_QUIT("forcly_disable_driver_quit"),
+        FORCIBLY_DISABLE_DRIVER_QUIT("forcibly_disable_driver_quit"),
 
         // TestRail
         TESTRAIL_RUN_NAME("testrail_run_name"),

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -49,6 +49,7 @@ import com.qaprosoft.carina.core.foundation.webdriver.screenshot.IScreenshotRule
 import com.qaprosoft.zafira.util.upload.UploadUtil;
 
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.windows.WindowsDriver;
 import ru.yandex.qatools.ashot.AShot;
 import ru.yandex.qatools.ashot.comparison.ImageDiff;
 import ru.yandex.qatools.ashot.comparison.ImageDiffer;
@@ -467,7 +468,10 @@ public class Screenshot {
      */
     private static BufferedImage takeFullScreenshot(WebDriver driver, WebDriver augmentedDriver) throws Exception {
         BufferedImage screenShot;
-        if (driver.getClass().toString().contains("java_client")) {
+        if (driver.getClass().toString().contains("windows")) {
+            File screenshot = ((WindowsDriver<?>) driver).getScreenshotAs(OutputType.FILE);
+            screenShot = ImageIO.read(screenshot);
+        } else if (driver.getClass().toString().contains("java_client")) {
             // Mobile Native app
             File screenshot = ((AppiumDriver<?>) driver).getScreenshotAs(OutputType.FILE);
             screenShot = ImageIO.read(screenshot);

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/impl/windows/WindowsCapabilies.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/impl/windows/WindowsCapabilies.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright 2013-2020 QaProSoft (http://www.qaprosoft.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.qaprosoft.carina.core.foundation.webdriver.core.capability.impl.windows;
+
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import com.qaprosoft.carina.core.foundation.webdriver.core.capability.AbstractCapabilities;
+
+public class WindowsCapabilies extends AbstractCapabilities {
+    
+
+    @Override
+    public DesiredCapabilities getCapability(String testName) {
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities = initCapabilities(capabilities);
+        return capabilities;
+    }    
+}

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/DriverFactory.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/DriverFactory.java
@@ -31,6 +31,7 @@ import com.qaprosoft.carina.core.foundation.utils.Configuration;
 import com.qaprosoft.carina.core.foundation.utils.Configuration.Parameter;
 import com.qaprosoft.carina.core.foundation.webdriver.core.factory.impl.DesktopFactory;
 import com.qaprosoft.carina.core.foundation.webdriver.core.factory.impl.MobileFactory;
+import com.qaprosoft.carina.core.foundation.webdriver.core.factory.impl.WindowsFactory;
 import com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener;
 import com.qaprosoft.zafira.client.ZafiraSingleton;
 import com.qaprosoft.zafira.models.dto.TestArtifactType;
@@ -63,6 +64,10 @@ public class DriverFactory {
 		case SpecialKeywords.MOBILE:
 			factory = new MobileFactory();
 			break;
+
+        case SpecialKeywords.WINDOWS:
+            factory = new WindowsFactory();
+            break;
 
 		default:
 			throw new RuntimeException("Unsupported driver_type: " + driverType);

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/WindowsFactory.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/WindowsFactory.java
@@ -95,8 +95,7 @@ public class WindowsFactory extends AbstractFactory {
 
     @Override
     public WebDriver registerListeners(WebDriver driver, WebDriverEventListener... listeners) {
-        // return super.registerListeners(driver, listeners);
-        return driver;
+        return super.registerListeners(driver, listeners);
     }
 
 }

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/WindowsFactory.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/factory/impl/WindowsFactory.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright 2013-2020 QaProSoft (http://www.qaprosoft.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.qaprosoft.carina.core.foundation.webdriver.core.factory.impl;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.log4j.Logger;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.support.events.WebDriverEventListener;
+
+import com.qaprosoft.carina.core.foundation.commons.SpecialKeywords;
+import com.qaprosoft.carina.core.foundation.utils.Configuration;
+import com.qaprosoft.carina.core.foundation.webdriver.core.capability.impl.windows.WindowsCapabilies;
+import com.qaprosoft.carina.core.foundation.webdriver.core.factory.AbstractFactory;
+
+import io.appium.java_client.ios.IOSStartScreenRecordingOptions.VideoQuality;
+import io.appium.java_client.windows.WindowsDriver;
+import io.appium.java_client.windows.WindowsElement;
+
+/**
+ * WindowsFactory creates instance {@link WebDriver} for Windows native application testing.
+ * 
+ * @author Sergei Zagriychuk (sergeizagriychuk@gmail.com)
+ */
+public class WindowsFactory extends AbstractFactory {
+    private static final Logger LOGGER = Logger.getLogger(WindowsFactory.class);
+
+    @Override
+    public WebDriver create(String name, DesiredCapabilities capabilities, String seleniumHost) {
+
+        if (seleniumHost == null) {
+            seleniumHost = Configuration.get(Configuration.Parameter.SELENIUM_HOST);
+        }
+        LOGGER.debug("selenium: " + seleniumHost);
+
+        String driverType = Configuration.getDriverType(capabilities);
+        if (!SpecialKeywords.WINDOWS.equals(driverType)) {
+            throw new RuntimeException(String.format("Driver type %s is not applicable for Windows driver", driverType));
+        }
+
+        WindowsDriver<WindowsElement> driver = null;
+        if (isCapabilitiesEmpty(capabilities)) {
+            capabilities = getCapabilities(name);
+        }
+        
+        URL url;
+        try {
+            url = new URL(seleniumHost);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Malformed appium URL!", e);
+        }
+        driver = new WindowsDriver<WindowsElement>(url, capabilities);
+
+        return driver;
+    }
+
+    private DesiredCapabilities getCapabilities(String name) {
+        return new WindowsCapabilies().getCapability(name);
+    }
+
+    @Override
+    protected int getBitrate(VideoQuality quality) {
+        switch (quality) {
+        case LOW:
+            return 250000;
+        case MEDIUM:
+            return 500000;
+        case HIGH:
+            return 1000000;
+        default:
+            return 1;
+        }
+    }
+
+    @Override
+    public String getVncURL(WebDriver driver) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WebDriver registerListeners(WebDriver driver, WebDriverEventListener... listeners) {
+        // return super.registerListeners(driver, listeners);
+        return driver;
+    }
+
+}

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/PageOpeningStrategy.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/PageOpeningStrategy.java
@@ -1,0 +1,7 @@
+package com.qaprosoft.carina.core.foundation.webdriver.decorator;
+
+public enum PageOpeningStrategy {
+    BY_ELEMENT,
+    BY_URL,
+    BY_URL_AND_ELEMENT
+}

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/gui/AbstractPage.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/gui/AbstractPage.java
@@ -161,6 +161,8 @@ public abstract class AbstractPage extends AbstractUIObject implements ICustomTy
                                 uiLoadedMarker.getBy().toString()));
             }
             break;
+        default:
+            throw new RuntimeException("Page opening strategy was not applied properly");
         }
     }
 

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/gui/AbstractPage.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/gui/AbstractPage.java
@@ -37,6 +37,7 @@ import com.qaprosoft.carina.core.foundation.utils.Configuration;
 import com.qaprosoft.carina.core.foundation.utils.Configuration.Parameter;
 import com.qaprosoft.carina.core.foundation.utils.factory.ICustomTypePageFactory;
 import com.qaprosoft.carina.core.foundation.webdriver.Screenshot;
+import com.qaprosoft.carina.core.foundation.webdriver.decorator.PageOpeningStrategy;
 
 /**
  * All page POJO objects should extend this abstract page to get extra logic.
@@ -44,6 +45,8 @@ import com.qaprosoft.carina.core.foundation.webdriver.Screenshot;
  * @author Alex Khursevich
  */
 public abstract class AbstractPage extends AbstractUIObject implements ICustomTypePageFactory {
+
+    private PageOpeningStrategy pageOpeningStrategy = PageOpeningStrategy.valueOf(Configuration.get(Parameter.PAGE_OPENING_STRATEGY));
 
 	private static final Logger LOGGER = Logger.getLogger(AbstractPage.class);
     
@@ -79,26 +82,46 @@ public abstract class AbstractPage extends AbstractUIObject implements ICustomTy
         return pageURL;
     }
 
+    public PageOpeningStrategy getPageOpeningStrategy() {
+        return pageOpeningStrategy;
+    }
+
+    public void setPageOpeningStrategy(PageOpeningStrategy pageOpeningStrategy) {
+        this.pageOpeningStrategy = pageOpeningStrategy;
+    }
+
     public boolean isPageOpened() {
         return isPageOpened(EXPLICIT_TIMEOUT);
     }
 
     public boolean isPageOpened(long timeout) {
-        boolean isOpened = super.isPageOpened(this, timeout);
-        if (!isOpened) {
-            return false;
-        }
+        switch (pageOpeningStrategy) {
+        case BY_URL:
+            return super.isPageOpened(this, timeout);
+        case BY_ELEMENT:
+            if (uiLoadedMarker == null) {
+                throw new RuntimeException("Please specify uiLoadedMarker for the page/screen to validate page opened state");
+            }
+            return uiLoadedMarker.isElementPresent(timeout);
+        case BY_URL_AND_ELEMENT:
+            boolean isOpened = super.isPageOpened(this, timeout);
+            if (!isOpened) {
+                return false;
+            }
 
-        if (uiLoadedMarker != null) {
-            isOpened = uiLoadedMarker.isVisible(timeout);
-        }
+            if (uiLoadedMarker != null) {
+                isOpened = uiLoadedMarker.isElementPresent(timeout);
+            }
 
-        if (!isOpened) {
-            LOGGER.warn(String.format(
-                    "Loaded page url is as expected but page loading marker element is not visible: %s",
-                    uiLoadedMarker.getBy().toString()));
+            if (!isOpened) {
+                LOGGER.warn(String.format(
+                        "Loaded page url is as expected but page loading marker element is not visible: %s",
+                        uiLoadedMarker.getBy().toString()));
+            }
+            return isOpened;
+        default:
+            throw new RuntimeException("Page opening strategy was not applied properly");
         }
-        return isOpened;
     }
 
     /**
@@ -116,14 +139,28 @@ public abstract class AbstractPage extends AbstractUIObject implements ICustomTy
      * @param timeout Completing of page loading conditions will be verified within specified timeout
      */
     public void assertPageOpened(long timeout) {
-        if (!super.isPageOpened(this, timeout)) {
-            Assert.fail(String.format("%s not loaded: url is not as expected", getPageClassName()));
-        }
+        switch (pageOpeningStrategy) {
+        case BY_URL:
+            Assert.assertTrue(super.isPageOpened(this, timeout), String.format("%s not loaded: url is not as expected", getPageClassName()));
+            break;
+        case BY_ELEMENT:
+            if (uiLoadedMarker == null) {
+                throw new RuntimeException("Please specify uiLoadedMarker for the page/screen to validate page opened state");
+            }
+            Assert.assertTrue(uiLoadedMarker.isElementPresent(timeout), String.format("%s not loaded: page loading marker element is not visible: %s",
+                    getPageClassName(), uiLoadedMarker.getBy().toString()));
+            break;
+        case BY_URL_AND_ELEMENT:
+            if (!super.isPageOpened(this, timeout)) {
+                Assert.fail(String.format("%s not loaded: url is not as expected", getPageClassName()));
+            }
 
-        if (uiLoadedMarker != null) {
-            Assert.assertTrue(uiLoadedMarker.isVisible(timeout),
-                    String.format("%s not loaded: url is correct but page loading marker element is not visible: %s",
-                            getPageClassName(), uiLoadedMarker.getBy().toString()));
+            if (uiLoadedMarker != null) {
+                Assert.assertTrue(uiLoadedMarker.isElementPresent(timeout),
+                        String.format("%s not loaded: url is correct but page loading marker element is not visible: %s", getPageClassName(),
+                                uiLoadedMarker.getBy().toString()));
+            }
+            break;
         }
     }
 

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/gui/AbstractUIObject.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/gui/AbstractUIObject.java
@@ -106,6 +106,14 @@ public abstract class AbstractUIObject extends DriverHelper {
         this.uiLoadedMarker = uiLoadedMarker;
     }
 
+    public ElementLoadingStrategy getLoadingStrategy() {
+        return loadingStrategy;
+    }
+
+    public void setLoadingStrategy(ElementLoadingStrategy loadingStrategy) {
+        this.loadingStrategy = loadingStrategy;
+    }
+
     public String getName() {
         return name;
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -399,6 +399,16 @@ All the project configuration properties are located in a **_config.properties**
 		<td>Determines how carina detects appearing of web elements on page: by presence in DOM model or by visibility or by any of these conditions</td>
 		<td>BY_PRESENCE, BY_VISIBILITY, BY_PRESENCE_OR_VISIBILITY</td>
 	</tr>
+	<tr>
+		<td>page_opening_strategy</td>
+		<td>Determines how carina detects whether expected page is opened: by expected url pattern, by marker element loading state or by both these conditions</td>
+		<td>BY_ELEMENT, BY_URL, BY_URL_AND_ELEMENT</td>
+	</tr>
+	<tr>
+		<td>forcibly_disable_driver_quit</td>
+		<td>If enabled turns off webdriver shutdown after test finishing by any reason. Default value is 'false'</td>
+		<td>false, true</td>
+	</tr>
 </table>
 Most of the properties may be read in the following way:
 ```


### PR DESCRIPTION
- added support of WinAppDriver usage; capabilities.platformName=Windows should be set for that
- PageOpeningStrategy was introduced. It allows to determine page loading state by marker element visibility; url equality; url + element
- FORCIBLY_DISABLE_DRIVER_QUIT flag was introduced. it allows to disable driver quit at all stages of test execution process. In some cases that's needed for testing of Windows applications