### PR TITLE
build-snapshot: Exception handling in getting of screenshots link for the report

### DIFF
--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -608,9 +608,8 @@ public class ReportContext {
             }
         } catch (Exception e) {
             LOGGER.error("Exception during report directory scanning", e);
-            e.printStackTrace();
         }
-
+        
         String test = testDirectory.get().getName().replaceAll("[^a-zA-Z0-9.-]", "_");
         
         if (!Configuration.get(Parameter.REPORT_URL).isEmpty()) {

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -601,11 +601,16 @@ public class ReportContext {
      */
     public static String getTestScreenshotsLink() {
         String link = "";
-        if (FileUtils.listFiles(ReportContext.getTestDir(), new String[] { "png" }, false).isEmpty()) {
-            // no png screenshot files at all
-            return link;
+        try {
+            if (FileUtils.listFiles(ReportContext.getTestDir(), new String[] { "png" }, false).isEmpty()) {
+                // no png screenshot files at all
+                return link;
+            }
+        } catch (Exception e) {
+            LOGGER.error("Exception during report directory scanning", e);
+            e.printStackTrace();
         }
-        
+
         String test = testDirectory.get().getName().replaceAll("[^a-zA-Z0-9.-]", "_");
         
         if (!Configuration.get(Parameter.REPORT_URL).isEmpty()) {


### PR DESCRIPTION
In some cases tests are getting skipped because of exception in screenshots link getting method.
To prevent that I added exception handling + logging of caught exception message
Example:
`[2020-07-24T09:21:46.990Z] 2020-07-24 09:21:46 Messager [TestNG-tests-8-37] [INFO]  TEST [Gift card test - testValidateGiftCardPlaceholder] PASSED at [09:21:46 2020-07-24]
[2020-07-24T09:21:46.990Z] 2020-07-24 09:21:46 Screenshot [TestNG-tests-8-37] [INFO] Default carina screenshot capturing rules are disabled!
[2020-07-24T09:21:46.990Z] 2020-07-24 09:21:46 Messager [TestNG-tests-8-37] [ERROR]  TEST [Gift card test - testValidateGiftCardPlaceholder] FAILED at [09:21:46 2020-07-24] - Parameter 'directory' is not a directory: /opt/jenkins/workspace/underarmour/phoenix-auto-qa/PHOENIX-PROD-WEB-Acceptance-Chrome/././../reports/qa/1595582060078/26198d62-a6ee-4c0c-84ad-0264687bf240
[2020-07-24T09:21:46.990Z] 
[2020-07-24T09:21:46.990Z] org.apache.commons.io.FileUtils.validateListFilesParameters(FileUtils.java:536)
[2020-07-24T09:21:46.990Z] org.apache.commons.io.FileUtils.listFiles(FileUtils.java:512)
[2020-07-24T09:21:46.990Z] org.apache.commons.io.FileUtils.listFiles(FileUtils.java:684)
[2020-07-24T09:21:46.990Z] com.qaprosoft.carina.core.foundation.report.ReportContext.getTestScreenshotsLink(ReportContext.java:604)
[2020-07-24T09:21:46.990Z] com.qaprosoft.carina.core.foundation.listeners.AbstractTestListener.createTestResult(AbstractTestListener.java:405)
[2020-07-24T09:21:46.990Z] com.qaprosoft.carina.core.foundation.listeners.AbstractTestListener.passItem(AbstractTestListener.java:66)
[2020-07-24T09:21:46.990Z] com.qaprosoft.carina.core.foundation.listeners.AbstractTestListener.onTestSuccess(AbstractTestListener.java:300)
[2020-07-24T09:21:46.990Z] com.qaprosoft.carina.core.foundation.listeners.CarinaListener.onTestSuccess(CarinaListener.java:274)`