### PR TITLE
Using default value for VideoAnalyzer isEnabled

### DIFF
--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/video/VideoAnalyzer.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/video/VideoAnalyzer.java
@@ -5,7 +5,7 @@ import org.apache.log4j.Logger;
 public class VideoAnalyzer {
     private static final Logger LOGGER = Logger.getLogger(VideoAnalyzer.class);
 
-    private static ThreadLocal<Boolean> uploadVideo = new ThreadLocal<Boolean>();
+    private static final ThreadLocal<Boolean> uploadVideo = ThreadLocal.withInitial(() -> false);
 
     public static void disableVideoUpload() {
         uploadVideo.set(Boolean.FALSE);

--- a/carina-utils/src/test/java/com/qaprosoft/carina/core/foundation/utils/video/VideoAnalyzerTest.java
+++ b/carina-utils/src/test/java/com/qaprosoft/carina/core/foundation/utils/video/VideoAnalyzerTest.java
@@ -1,0 +1,29 @@
+package com.qaprosoft.carina.core.foundation.utils.video;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Created by Quang Le (quangltp) on 10/5/20
+ */
+
+public class VideoAnalyzerTest {
+    @Test
+    public void testIsVideoUploadNotEnabled() {
+        VideoAnalyzer.disableVideoUpload();
+        Assert.assertFalse(VideoAnalyzer.isVideoUploadEnabled(), "Is Video Upload Enabled");
+    }
+
+    @Test
+    public void testIsVideoUploadEnabled() {
+        VideoAnalyzer.enableVideoUpload();
+        Assert.assertTrue(VideoAnalyzer.isVideoUploadEnabled(), "Is Video Upload Enabled");
+    }
+
+    @Test
+    public void testDefaultIsVideoUploadEnabled() {
+        Assert.assertFalse(VideoAnalyzer.isVideoUploadEnabled(), "Is Video Upload Enabled");
+    }
+}


### PR DESCRIPTION
### Context

The `VideoAnalyzer`'s `uploadVideo` property is initialized in `AbstractTestListener`, when start/stop test, and retrieved in `IDriverPool`, when someone calls `quitDriver`.

### Problem

There are cases when we call `quitDriver`, without invoking `AbstractTestListener`, e.g. using Carina from `main` class, without any testing framework. In such a case, `NullPointerException` will arise because `uploadVideo` has not been set beforehand.

### Solution

Initialize `uploadVideo` with default value to `false`.
