### PR TITLE
build-snapshot: Throw timeout exception when waiting time elapsed before the adb exec…

### DIFF
--- a/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
+++ b/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
@@ -150,7 +150,8 @@ public class SpecialKeywords {
     public static final String PLATFORM = "capabilities.platform";
     public static final String PLATFORM_NAME = "capabilities.platformName";
     public static final String PLATFORM_VERSION = "capabilities.platformVersion";
-    
+
+    public static final String ADB_EXEC_TIMEOUT = "capabilities.adbExecTimeout";
     public static final String MOBILE_DEVICE_UDID = "capabilities.udid";
     public static final String MOBILE_DEVICE_NAME = "capabilities.deviceName";
     public static final String MOBILE_DEVICE_BROWSERSTACK_NAME = "capabilities.device";
@@ -196,6 +197,7 @@ public class SpecialKeywords {
 
 
     // ------------- Mobile screenshots cutting strategies configuration  ---------------
+    public static final int DEFAULT_ADB_EXEC_TIMEOUT = 20000;
     public static final int DEFAULT_SCROLL_TIMEOUT = 100;
     public static final int DEFAULT_BLOCK = 0;
     public static final int DEFAULT_IOS_HEADER = 74;

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -354,6 +354,23 @@ public class Configuration {
     }
 
     /**
+     * Get capabilities.adbExecTimeout from configuration properties.
+     * if it is missing return the default value
+     * @return int capabilities.adbExecTimeout
+     */
+    public static int getAdbExecTimeout() {
+        // default "capabilities.adbExecTimeout=value" should be used to determine current platform
+        int adbExecTimeout = SpecialKeywords.DEFAULT_ADB_EXEC_TIMEOUT;
+
+        // redefine adb exec timeout if capabilities.AdbExecTimeout is available
+        if (!R.CONFIG.get(SpecialKeywords.ADB_EXEC_TIMEOUT).isEmpty()) {
+            adbExecTimeout = R.CONFIG.getInt(SpecialKeywords.ADB_EXEC_TIMEOUT);
+        }
+
+        return adbExecTimeout;
+    }
+
+    /**
      * Get platform name from configuration properties.
      * @return String platform name
      */

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/recorder/utils/AdbExecutor.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/android/recorder/utils/AdbExecutor.java
@@ -20,9 +20,12 @@ import java.io.Closeable;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.qaprosoft.carina.core.foundation.utils.Configuration;
 import org.apache.log4j.Logger;
 
 /**
@@ -91,6 +94,9 @@ public class AdbExecutor {
             executor = new ProcessBuilderExecutor(cmd);
 
             Process process = executor.start();
+            if (!process.waitFor(Configuration.getAdbExecTimeout(), TimeUnit.MILLISECONDS)) {
+                throw new TimeoutException("Waiting time elapsed before the adb execution command has exited");
+            }
             in = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line = null;
 


### PR DESCRIPTION
…ution command has exited

Tested in Karina demo. Implemented page class from IMobileUtils. And the object of this class in the test called the executeAdbCommand method. Reduced latency to minimum in _config.properties and got TimeoutException as a result.
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
