### PR TITLE
build-snapshot: Using Arrays.toString() instead of toString()

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/listener/DriverListener.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/listener/DriverListener.java
@@ -16,6 +16,7 @@
 package com.qaprosoft.carina.core.foundation.webdriver.listener;
 
 import java.io.File;
+import java.util.Arrays;
 
 import com.qaprosoft.zafira.util.UploadUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -195,8 +196,8 @@ public class DriverListener implements WebDriverEventListener {
         
         // hopefully castDriver below resolve root cause of the recursive onException calls but keep below if to ensure
         if (thr.getStackTrace() != null
-                && (thr.getStackTrace().toString().contains("com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException") ||
-                        thr.getStackTrace().toString().contains("Unable to capture screenshot due to the WebDriverException"))) {
+                && (Arrays.toString(thr.getStackTrace()).contains("com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException")
+                || Arrays.toString(thr.getStackTrace()).contains("Unable to capture screenshot due to the WebDriverException"))) {
             LOGGER.error("Do not generate screenshot for invalid driver!");
             // prevent recursive crash for onException
             return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
