### PR TITLE
build-snapshot: Re-interrupt after catching InterruptedException in carina-webdriver …

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
@@ -368,8 +368,11 @@ public interface IDriverPool {
             long wait = 120;
             try {
                 future.get(wait, TimeUnit.SECONDS);
-            } catch (InterruptedException | java.util.concurrent.TimeoutException e) {
+            } catch (java.util.concurrent.TimeoutException e) {
                 POOL_LOGGER.error("Unable to quit driver for " + wait + "sec!", e);
+            } catch (InterruptedException e) {
+                POOL_LOGGER.error("Unable to quit driver for " + wait + "sec!", e);
+                Thread.currentThread().interrupt();
             } catch (ExecutionException e) {
                 POOL_LOGGER.warn("ExecutionException error on driver quit detected!");
                 POOL_LOGGER.debug(e.getMessage(), e);


### PR DESCRIPTION
…module

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
