### PR TITLE
Add more conditions to skip taking screenshots

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -568,6 +568,7 @@ public class Screenshot {
 				|| message.contains("chrome not reachable")
 				|| message.contains("cannot forward the request Connect to")
 				|| message.contains("Could not proxy command to remote server. Original error:") // Error: socket hang up, Error: read ECONNRESET etc				
+				|| message.contains("Could not proxy command to the remote server. Original error:") // Different messages on some Appium versions
 				|| message.contains("Unable to find elements by Selenium")
 				|| message.contains("generateUiDump") //do not generate screenshot if getPageSource is invalid
 				|| message.contains("Expected to read a START_MAP but instead have: END") // potential drivers issues fix for moon

--- a/carina-webdriver/src/test/java/com/qaprosoft/carina/core/foundation/webdriver/ScreenshotTest.java
+++ b/carina-webdriver/src/test/java/com/qaprosoft/carina/core/foundation/webdriver/ScreenshotTest.java
@@ -1,0 +1,24 @@
+package com.qaprosoft.carina.core.foundation.webdriver;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Created by Quang Le (quangltp) on 11/12/20
+ */
+
+public class ScreenshotTest {
+
+    @Test
+    public void testIsCaptured() {
+        String message = "An unknown server-side error occurred while processing the command. Original error: Could not proxy. Proxy error: Could not proxy command to the remote server. Original error: read ECONNRESET\n" +
+                "Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'\n" +
+                "System info: host: 'Defaultstring', ip: '127.0.0.1', os.name: 'Linux', os.arch: 'amd64', os.version: '5.4.0-52-generic', java.version: '1.8.0_272'\n" +
+                "Driver info: io.appium.java_client.android.AndroidDriver\n" +
+                "Capabilities {adbExecTimeout: 60000, appActivity: com.ltpquang.myapp.ui.activ..., appPackage: com.ltpquang.myapp, automationName: uiAutomator2, databaseEnabled: false, desired: {adbExecTimeout: 60000, appActivity: com.ltpquang.myapp.ui.activ..., appPackage: com.ltpquang.myapp, automationName: uiAutomator2, fullReset: false, newCommandTimeout: 0, noReset: true, platformName: android, udid: 271cb07cbf217ece}, deviceApiLevel: 28, deviceManufacturer: samsung, deviceModel: SM-N960N, deviceName: 271cb07ck3nfh8ce, deviceScreenDensity: 420, deviceScreenSize: 1080x2220, deviceUDID: 271cb07ck3nfh8ce, fullReset: false, javascriptEnabled: true, locationContextEnabled: false, networkConnectionEnabled: true, newCommandTimeout: 0, noReset: true, pixelRatio: 2.625, platform: LINUX, platformName: Android, platformVersion: 9, statBarHeight: 63, takesScreenshot: true, udid: 271cb07cbf217ece, viewportRect: {height: 2118, left: 0, top: 63, width: 1080}, warnings: {}, webStorageEnabled: false}\n" +
+                "Session ID: 7ec50037-37b7-41a6-a6f2-57c56ecfc425";
+        Assert.assertFalse(Screenshot.isCaptured(message));
+    }
+}


### PR DESCRIPTION
Appium 1.18.3 is output some error messages that `Screenshot` cannot detect to skip screenshoting. This causes stackoverflow.

```
Session ID: 7ec50037-37b7-41a6-a6f2-57c56ecfc425
	at sun.reflect.GeneratedConstructorAccessor17.newInstance(Unknown Source)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.EventFiringAppiumCommandExecutor.execute(EventFiringAppiumCommandExecutor.java:151)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
	at io.appium.java_client.DefaultGenericMobileDriver.execute(DefaultGenericMobileDriver.java:45)
	at io.appium.java_client.AppiumDriver.execute(AppiumDriver.java:1)
	at io.appium.java_client.android.AndroidDriver.execute(AndroidDriver.java:1)
	at org.openqa.selenium.remote.RemoteWebDriver.getScreenshotAs(RemoteWebDriver.java:295)
	at com.qaprosoft.carina.core.foundation.webdriver.Screenshot.takeFullScreenshot(Screenshot.java:467)
	at com.qaprosoft.carina.core.foundation.webdriver.Screenshot.capture(Screenshot.java:378)
	at com.qaprosoft.carina.core.foundation.webdriver.Screenshot.capture(Screenshot.java:170)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:288)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$1(EventFiringWebDriver.java:107)
	at io.appium.java_client.android.$Proxy39.getPageSource(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver.getPageSource(EventFiringWebDriver.java:201)
	at com.qaprosoft.carina.core.foundation.webdriver.device.Device.generateUiDump(Device.java:580)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.generateDump(DriverListener.java:307)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.captureScreenshot(DriverListener.java:291)
	at com.qaprosoft.carina.core.foundation.webdriver.listener.DriverListener.onException(DriverListener.java:212)
	at sun.reflect.GeneratedMethodAccessor73.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver.lambda$new$0(EventFiringWebDriver.java:84)
	at com.sun.proxy.$Proxy38.onException(Unknown Source)
```
