### PR TITLE
Implemented option for not adding demo sources on archetype

### DIFF
--- a/archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,0 +1,37 @@
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import static org.apache.commons.io.FileUtils.deleteDirectory
+import static org.apache.commons.io.FileUtils.cleanDirectory
+import static org.apache.commons.io.FileUtils.copyDirectory
+
+Path projectPath = Paths.get(request.outputDirectory, request.artifactId)
+Properties properties = request.properties
+String packageName = properties.get("package")
+String packagePath = packageName.replace(".", "/")
+boolean demo = Boolean.parseBoolean(properties.getProperty("demo"))
+
+if (!demo) {
+    copyDirectory (projectPath.resolve("src/main/java/$packagePath/carina/demo").toFile(),
+            projectPath.resolve("src/main/java/$packagePath").toFile())
+    deleteDirectory projectPath.resolve("src/main/java/$packagePath/carina").toFile()
+
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/api").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/db/mappers").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/db/models").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/gui/components").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/gui/pages").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/mobile/gui/pages/android").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/mobile/gui/pages/common").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/mobile/gui/pages/ios").toFile()
+    cleanDirectory projectPath.resolve("src/main/java/$packagePath/utils").toFile()
+
+    cleanDirectory projectPath.resolve("src/main/resources/L10N").toFile()
+
+    deleteDirectory projectPath.resolve("src/test/java/$packagePath/carina").toFile()
+
+    cleanDirectory projectPath.resolve("src/test/resources/xls").toFile()
+    cleanDirectory projectPath.resolve("src/test/resources/features").toFile()
+    cleanDirectory projectPath.resolve("src/test/resources/testng_suites").toFile()
+    cleanDirectory projectPath.resolve("src/test/resources/api").toFile()
+}

--- a/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -21,6 +21,9 @@
         <requiredProperty key="url">
             <defaultValue>https://qaprosoft.com</defaultValue>
         </requiredProperty>
+        <requiredProperty key="demo">
+            <defaultValue>true</defaultValue>
+        </requiredProperty>
   </requiredProperties>
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/archetype/src/test/resources/projects/basic/archetype.properties
+++ b/archetype/src/test/resources/projects/basic/archetype.properties
@@ -9,3 +9,4 @@ selenium_host=http://localhost:4444/wd/hub
 zafira_enabled=false
 zafira_service_url=http://localhost:8080/zafira-ws
 zafira_access_token=changeit
+demo=true


### PR DESCRIPTION
Implemented option for not adding demo sources on archetype

Use -Ddemo=false when calling mvn archetype:generate for not adding demo files

resolve #1204 