### PR TITLE
build-snapshot:1225 changes for chrome adding pref for intl.accept_languages

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/AbstractCapabilities.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/AbstractCapabilities.java
@@ -181,21 +181,30 @@ public abstract class AbstractCapabilities {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("test-type");
         
+        //prefs 
+        HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+        boolean needsPrefs = false;
+        
         //update browser language
         String browserLang = Configuration.get(Parameter.BROWSER_LANGUAGE); 
         if (!browserLang.isEmpty()) {
             LOGGER.info("Set Chrome language to: " + browserLang);
             options.addArguments("--lang=" + browserLang);
+            chromePrefs.put("intl.accept_languages", browserLang);
+            needsPrefs = true;
         }
 
         if (Configuration.getBoolean(Configuration.Parameter.AUTO_DOWNLOAD)) {
-            HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
             chromePrefs.put("download.prompt_for_download", false);
             chromePrefs.put("download.default_directory", getAutoDownloadFolderPath());
             chromePrefs.put("plugins.always_open_pdf_externally", true);
-            options.setExperimentalOption("prefs", chromePrefs);
+            needsPrefs = true;
         }
 
+        if (needsPrefs) {
+        	options.setExperimentalOption("prefs", chromePrefs);
+        }
+        
         // [VD] no need to set proxy via options anymore!
         // moreover if below code is uncommented then we have double proxy start and mess in host:port values
         


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes in AbstractCapabilities method addChromeOptions
<!--- Describe your changes in details -->
In addChromeOptions, move the chromePrefs HashMap out of the if for AUTO_DOWNLOAD and add a boolean to denote whether we are adding any prefs.
In the if for browserLang, add the intl.accept_languages to the hashmap and set the boolean true
In the if for AUTO_DOWNLOAD, set the boolean true and move the adding of prefs to options out of this if.
Add an if our new boolean is true, then add prefs to the options.

Is there a way I can make this fix back on 6.5.46???

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
