### PR TITLE
Add agent's DataProviderInterceptor to the list of TestNG services

### DIFF
--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/IAbstractTest.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/IAbstractTest.java
@@ -49,7 +49,6 @@ import com.zebrunner.agent.testng.listener.TestRunListener;
 // on start order is TestRunListener and CarinaListener
 // on finish reverse order, i.e. CarinaListener, TestRunListener
 @LinkedListeners({ CarinaListener.class, TestRunListener.class, DataProviderInterceptor.class, FilterTestsListener.class })
-@Listeners({DataProviderInterceptor.class})
 public interface IAbstractTest extends ICustomTypePageFactory, ITestCases {
 
     long EXPLICIT_TIMEOUT = Configuration.getLong(Parameter.EXPLICIT_TIMEOUT);

--- a/carina-core/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/carina-core/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,1 +1,2 @@
 com.qaprosoft.carina.core.foundation.listeners.CarinaListenerChain
+com.zebrunner.agent.testng.listener.DataProviderInterceptor


### PR DESCRIPTION
As of now, agent's DataProviderInterceptor is completely ignored, so the data provider information is missing. The proposed config resurrects the DataProviderInterceptor as a TestNG listener